### PR TITLE
fix(server): derive 64-byte session key via SHA-512

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,6 +1496,7 @@ dependencies = [
  "fbkl-logic",
  "serde",
  "serde_json",
+ "sha2",
  "time",
  "tokio",
  "tower-cookies",

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,6 +22,7 @@ fbkl-jobs = {path = "../jobs"}
 fbkl-logic = {path = "../logic"}
 serde = {version = "1.0.228", features = ["derive"]}
 serde_json = "1.0.150"
+sha2 = "0.10.9"
 time = "0.3.47"
 tokio = {version = "1.52.3", features = ["full"]}
 tower-cookies = "0.11.0"

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -15,6 +15,7 @@ use color_eyre::Result;
 use fbkl_auth::{encode_token, generate_token};
 use fbkl_entity::sea_orm::Database;
 use server::AppState;
+use sha2::{Digest, Sha512};
 use time::Duration as TimeDuration;
 use tokio::{signal, task::AbortHandle};
 use tower_cookies::{CookieManagerLayer, Key, cookie::SameSite};
@@ -49,7 +50,10 @@ async fn main() -> Result<()> {
     );
     let session_secret = std::env::var("SESSION_SECRET")
         .unwrap_or_else(|_| encode_token(&generate_token().into_iter().collect()));
-    let key = Key::from(session_secret.as_bytes());
+    // `Key::from` requires >= 64 bytes; derive a fixed 64-byte key from the secret
+    // via SHA-512 so any-length SESSION_SECRET is accepted.
+    let key_bytes = Sha512::digest(session_secret.as_bytes());
+    let key = Key::from(&key_bytes);
     let session_layer = SessionManagerLayer::new(session_store)
         .with_private(key)
         .with_secure(true)


### PR DESCRIPTION
cookie 0.18.1's Key::from requires >= 64 bytes, so a short SESSION_SECRET (e.g. 16 bytes) panics with TooShort. Hash the secret with SHA-512 to produce a fixed 64-byte key, accepting any-length secret.

Note: changes the derived key, invalidating existing sessions.