### PR TITLE
ci: PR checks for Rust + frontend with caching

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,33 @@
+name: Setup Node
+description: Install pnpm + Node and workspace deps (node_modules cached, lockfile-keyed)
+
+inputs:
+  node-version:
+    description: Node.js version, used for both setup-node and the node_modules cache key
+    default: "26"
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v6
+
+    - uses: actions/setup-node@v7
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: pnpm
+
+    # Cache node_modules (lockfile-keyed) so a hit skips the install entirely.
+    - name: Cache node_modules
+      id: node-modules-cache
+      uses: actions/cache@v4
+      with:
+        path: |
+          node_modules
+          webapp-logged-in/node_modules
+          webapp-public/node_modules
+        key: node-modules-${{ runner.os }}-node${{ inputs.node-version }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+    - name: Install dependencies
+      if: steps.node-modules-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,87 @@
+# Path-filtered PR checks; logged-in typecheck runs the Rust schema generator before tsc (generated GraphQL types).
+name: ci
+
+on:
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.filter.outputs.rust }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'auth/**'
+              - 'constants/**'
+              - 'entity/**'
+              - 'graphql-generation/**'
+              - 'jobs/**'
+              - 'lambdas/**'
+              - 'logic/**'
+              - 'migration/**'
+              - 'server/**'
+              - 'transaction-processor/**'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+            frontend:
+              - 'webapp-logged-in/**'
+              - 'webapp-public/**'
+              - 'package.json'
+              - 'pnpm-lock.yaml'
+              # Schema-affecting Rust changes can break generated frontend types.
+              - 'graphql-generation/**'
+              - 'server/**'
+
+  rust:
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: moonrepo/setup-rust@v1
+        with:
+          components: clippy, rustfmt
+      - run: cargo fmt --all --check
+      # clippy compiles the workspace, so it subsumes `cargo check`.
+      - run: cargo clippy --workspace --all-targets -- -D warnings
+      - run: cargo test --workspace
+
+  lint:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-node
+      - run: pnpm lint
+
+  typecheck-logged-in:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: moonrepo/setup-rust@v1
+      - uses: ./.github/actions/setup-node
+      - run: cargo run -p fbkl-graphql-generation
+      - run: pnpm --filter "@fbkl/webapp-logged-in" graphql
+      - run: pnpm --filter "@fbkl/webapp-logged-in" exec tsc
+
+  typecheck-public:
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-node
+      - run: pnpm --filter "@fbkl/webapp-public" exec tsc


### PR DESCRIPTION
Adds a path-filtered `ci` workflow that runs on pull requests.

## Jobs
- **rust** — `cargo fmt --check`, `cargo clippy --all-targets -D warnings` (subsumes `cargo check`), `cargo test`
- **lint** — `pnpm lint` (oxlint)
- **typecheck-logged-in** — runs the Rust GraphQL schema generator + `pnpm graphql`, then `tsc` (generated types are gitignored)
- **typecheck-public** — `tsc`

## Caching
- Rust: `moonrepo/setup-rust` built-in cache
- node_modules: reusable `.github/actions/setup-node` composite, keyed on `pnpm-lock.yaml` (modeled on the boxed-frontend setup action)

## Notes
- `dorny/paths-filter` skips the slow Rust build on frontend-only PRs and vice versa; frontend filter also triggers on `server/**` + `graphql-generation/**` since those change generated types.
- Matches conventions from the existing `deploy.yml` (action versions, node 26).

https://claude.ai/code/session_012BsxH49SsEo5VwdvVmvexe