### PR TITLE
ci: add sccache for cross-job Rust compilation cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,15 @@ jobs:
     needs: changes
     if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy, rustfmt
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: rust-clippy-test
@@ -72,9 +76,13 @@ jobs:
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
+    env:
+      RUSTC_WRAPPER: sccache
+      SCCACHE_GHA_ENABLED: "true"
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.10
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: rust-graphql-gen


### PR DESCRIPTION
## Why

`Swatinem/rust-cache` caches per-job `target/` tarballs (registry + dep sources), but **compiled artifacts don't carry across jobs**. The `rust` job (clippy check-mode + test codegen) and `typecheck-logged-in` (graphql-gen codegen) each recompile shared deps like `tracing` from scratch. Same for clippy check-mode vs test codegen — genuinely different artifacts, correctly not shared.

## What

Add `mozilla-actions/sccache-action` with the GitHub Actions backend (`SCCACHE_GHA_ENABLED`) to both Rust jobs. sccache caches compiler outputs in one shared namespace keyed by compiler-input hash, so a dep compiled with a given flag set in one job **hits** when another job compiles the same thing with the same flags.

- Layers on top of rust-cache (still handles the registry index/downloads).
- Relies on `CARGO_INCREMENTAL=0`, which rust-cache already sets — no conflict.
- Backstops recompiles even when rust-cache restores a wrong-shaped `target/`.

## Verify

sccache prints a hit/miss/request summary at each job's end. First run = cold (populates). Subsequent runs on unchanged deps = high hit rate.

## Caveat

GHA cache has a 10 GB per-repo limit shared across sccache + rust-cache tarballs. If eviction thrashes, drop rust-cache's `target/` caching first (now partly redundant with sccache).

https://claude.ai/code/session_01BphenuyhqcNz4TnVCp5bXg