### PR TITLE
feat: player eligibility classification + RD/RDI guards

### DIFF
--- a/entity/src/entities/league_player.rs
+++ b/entity/src/entities/league_player.rs
@@ -19,12 +19,15 @@ pub struct Model {
     pub league_id: i64,
     /// This id field gets filled when a custom-created player for a specific league eventually gets added to an official (NBA/ESPN) database. This is used to tie in a player's historical record in a league to before they became an NBA player.
     pub real_player_id: Option<i64>,
-    /// Whether the player has ever been on an active NBA roster (rules §3.1.2). Normally `false`
-    /// here — a custom league player exists because he has no NBA entry yet; flipping to `true` is
-    /// the §11.3.1 trigger to move RDI→RD/1.
-    pub has_been_on_nba_roster: bool,
+    /// Whether the player has ever appeared in an in-season NBA game (rules §3.1.2). Normally
+    /// `false` here, since a custom league player exists precisely because he has no NBA entry yet.
+    pub has_played_nba_game: bool,
+    /// The season the player first appeared in NBA data, or `None` if he never has. Setting it is
+    /// the §11.3.1 trigger to move RDI→RD/1 from that season on, so an RDI who signs an NBA contract
+    /// without appearing in a game still has to move.
+    pub nba_first_season_end_of_season_year: Option<i16>,
     pub nba_roster_source: NbaRosterSource,
-    /// When `has_been_on_nba_roster` was last evaluated.
+    /// When the NBA facts above were last evaluated.
     pub nba_roster_asof: Option<DateTimeWithTimeZone>,
     /// Commissioner override of the derived classification (rules §3.1.2, §11.3.6). Wins when set.
     pub eligibility_override: Option<EligibilityClassification>,

--- a/entity/src/entities/league_player.rs
+++ b/entity/src/entities/league_player.rs
@@ -3,6 +3,8 @@
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 
+use crate::player::{EligibilityClassification, NbaRosterSource};
+
 /// A Basketball player customly created for a league. Reasons for this happening include:
 /// * A basketball player being drafted but not active in the NBA.
 /// * ...that's really about it.
@@ -17,6 +19,18 @@ pub struct Model {
     pub league_id: i64,
     /// This id field gets filled when a custom-created player for a specific league eventually gets added to an official (NBA/ESPN) database. This is used to tie in a player's historical record in a league to before they became an NBA player.
     pub real_player_id: Option<i64>,
+    /// Whether the player has ever been on an active NBA roster (rules §3.1.2). Normally `false`
+    /// here — a custom league player exists because he has no NBA entry yet; flipping to `true` is
+    /// the §11.3.1 trigger to move RDI→RD/1.
+    pub has_been_on_nba_roster: bool,
+    pub nba_roster_source: NbaRosterSource,
+    /// When `has_been_on_nba_roster` was last evaluated.
+    pub nba_roster_asof: Option<DateTimeWithTimeZone>,
+    /// Commissioner override of the derived classification (rules §3.1.2, §11.3.6). Wins when set.
+    pub eligibility_override: Option<EligibilityClassification>,
+    pub eligibility_override_reason: Option<String>,
+    pub eligibility_override_by_team_user_id: Option<i64>,
+    pub eligibility_override_at: Option<DateTimeWithTimeZone>,
     pub created_at: DateTimeWithTimeZone,
     pub updated_at: DateTimeWithTimeZone,
 }

--- a/entity/src/entities/player.rs
+++ b/entity/src/entities/player.rs
@@ -27,6 +27,16 @@ pub struct Model {
     pub nba_id: Option<i32>,
     pub position_id: i32,
     pub status: PlayerStatus,
+    /// Whether the player has ever been on an active NBA roster (rules §3.1.2) — the auction-vs-draft pivot.
+    pub has_been_on_nba_roster: bool,
+    pub nba_roster_source: NbaRosterSource,
+    /// When `has_been_on_nba_roster` was last evaluated.
+    pub nba_roster_asof: Option<DateTimeWithTimeZone>,
+    /// Commissioner override of the derived classification (rules §3.1.2, §11.3.6). Wins when set.
+    pub eligibility_override: Option<EligibilityClassification>,
+    pub eligibility_override_reason: Option<String>,
+    pub eligibility_override_by_team_user_id: Option<i64>,
+    pub eligibility_override_at: Option<DateTimeWithTimeZone>,
     pub current_real_team_id: i64,
     pub created_at: DateTimeWithTimeZone,
     pub updated_at: DateTimeWithTimeZone,
@@ -75,6 +85,53 @@ pub enum PlayerStatus {
     /// Player exists as an active player in either ESPN fantasy or the NBA's player data.
     #[sea_orm(string_value = "Active")]
     Active,
+}
+
+/// Which acquisition pool a player belongs to. Always derived (see `logic::eligibility`), never
+/// stored as a column — only `eligibility_override` is persisted.
+#[derive(
+    Debug, Clone, Copy, Eq, PartialEq, Enum, EnumIter, DeriveActiveEnum, Serialize, Deserialize,
+)]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::None)")]
+pub enum EligibilityClassification {
+    /// Never on an NBA roster and in the rules §7.5.1 eligible set.
+    #[sea_orm(string_value = "RookieDraftEligible")]
+    RookieDraftEligible,
+    /// Has been on an active NBA roster (rules §6.2.1).
+    #[sea_orm(string_value = "VeteranAuctionEligible")]
+    VeteranAuctionEligible,
+    /// Rules §7.5.2 / §8.4.2 — current college/HS, undrafted foreign non-collegian, etc.
+    #[sea_orm(string_value = "Ineligible")]
+    Ineligible,
+}
+
+/// Provenance of `has_been_on_nba_roster`.
+#[derive(
+    Debug,
+    Default,
+    Clone,
+    Copy,
+    Eq,
+    PartialEq,
+    Enum,
+    EnumIter,
+    DeriveActiveEnum,
+    Serialize,
+    Deserialize,
+)]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::None)")]
+pub enum NbaRosterSource {
+    #[sea_orm(string_value = "BasketballReference")]
+    BasketballReference,
+    #[sea_orm(string_value = "Espn")]
+    Espn,
+    #[sea_orm(string_value = "Nba")]
+    Nba,
+    #[sea_orm(string_value = "CommissionerOverride")]
+    CommissionerOverride,
+    #[default]
+    #[sea_orm(string_value = "Unknown")]
+    Unknown,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/entity/src/entities/player.rs
+++ b/entity/src/entities/player.rs
@@ -27,10 +27,15 @@ pub struct Model {
     pub nba_id: Option<i32>,
     pub position_id: i32,
     pub status: PlayerStatus,
-    /// Whether the player has ever been on an active NBA roster (rules §3.1.2) — the auction-vs-draft pivot.
-    pub has_been_on_nba_roster: bool,
+    /// Whether the player has ever appeared in an in-season NBA game (rules §3.1.2). Combined with
+    /// `nba_first_season_end_of_season_year` to answer the auction-vs-draft pivot for a given season.
+    pub has_played_nba_game: bool,
+    /// The season the player first appeared in NBA data, or `None` if he never has. `Some(y)` with
+    /// `y <= season` is the rules §3.1.3 "has been on an active NBA roster" fact for that season,
+    /// which is broader than §3.1.2 and gates RDI (§11.3) rather than pool membership.
+    pub nba_first_season_end_of_season_year: Option<i16>,
     pub nba_roster_source: NbaRosterSource,
-    /// When `has_been_on_nba_roster` was last evaluated.
+    /// When the NBA facts above were last evaluated.
     pub nba_roster_asof: Option<DateTimeWithTimeZone>,
     /// Commissioner override of the derived classification (rules §3.1.2, §11.3.6). Wins when set.
     pub eligibility_override: Option<EligibilityClassification>,
@@ -94,10 +99,10 @@ pub enum PlayerStatus {
 )]
 #[sea_orm(rs_type = "String", db_type = "String(StringLen::None)")]
 pub enum EligibilityClassification {
-    /// Never on an NBA roster and in the rules §7.5.1 eligible set.
+    /// Never played in an NBA game and in the rules §7.5.1 eligible set.
     #[sea_orm(string_value = "RookieDraftEligible")]
     RookieDraftEligible,
-    /// Has been on an active NBA roster (rules §6.2.1).
+    /// Has played in an NBA game (rules §6.2.1).
     #[sea_orm(string_value = "VeteranAuctionEligible")]
     VeteranAuctionEligible,
     /// Rules §7.5.2 / §8.4.2 — current college/HS, undrafted foreign non-collegian, etc.
@@ -105,7 +110,7 @@ pub enum EligibilityClassification {
     Ineligible,
 }
 
-/// Provenance of `has_been_on_nba_roster`.
+/// Provenance of the NBA facts, which one ingest sets together.
 #[derive(
     Debug,
     Default,

--- a/entity/src/queries/contract_queries.rs
+++ b/entity/src/queries/contract_queries.rs
@@ -166,6 +166,27 @@ where
     Ok(contracts)
 }
 
+/// `find_active_contracts_in_league` narrowed to one season. This is the league's current roster +
+/// free-agency snapshot, which the eligibility pools read to exclude rostered players.
+#[instrument]
+pub async fn find_active_contracts_in_league_for_season<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    db: &C,
+) -> Result<Vec<contract::Model>>
+where
+    C: ConnectionTrait + Debug,
+{
+    let contracts = contract::Entity::find()
+        .filter(contract::Column::LeagueId.eq(league_id))
+        .filter(contract::Column::EndOfSeasonYear.eq(end_of_season_year))
+        .filter(contract::Column::Status.eq(contract::ContractStatus::Active))
+        .all(db)
+        .await?;
+
+    Ok(contracts)
+}
+
 /// Finds active contracts that belong to the given teams.
 #[instrument]
 pub async fn find_active_contracts_by_teams<C>(

--- a/entity/src/queries/eligibility_queries.rs
+++ b/entity/src/queries/eligibility_queries.rs
@@ -1,0 +1,63 @@
+//! Commissioner writes to the eligibility columns on `player` / `league_player` (spec 10).
+//!
+//! Two deliberately separate writes: the NBA-roster *fact* (which the feed also sets) and the
+//! commissioner's override of the *derived classification*. The pair is identical for both player
+//! tables, so one macro generates both.
+
+use chrono::Utc;
+use color_eyre::Result;
+use sea_orm::{ActiveModelTrait, ActiveValue, ConnectionTrait};
+
+use crate::player::{EligibilityClassification, NbaRosterSource};
+
+macro_rules! eligibility_writes {
+    ($entity:ident, $set_fact:ident, $set_override:ident) => {
+        /// Corrects the NBA-roster fact, marking the commissioner as its source.
+        pub async fn $set_fact<C>(
+            model: crate::$entity::Model,
+            has_been_on_nba_roster: bool,
+            db: &C,
+        ) -> Result<crate::$entity::Model>
+        where
+            C: ConnectionTrait,
+        {
+            let mut active_model: crate::$entity::ActiveModel = model.into();
+            active_model.has_been_on_nba_roster = ActiveValue::Set(has_been_on_nba_roster);
+            active_model.nba_roster_source =
+                ActiveValue::Set(NbaRosterSource::CommissionerOverride);
+            active_model.nba_roster_asof = ActiveValue::Set(Some(Utc::now().into()));
+            Ok(active_model.update(db).await?)
+        }
+
+        /// Overrides (or with `None`, clears) the derived classification plus its audit trail.
+        pub async fn $set_override<C>(
+            model: crate::$entity::Model,
+            classification: Option<EligibilityClassification>,
+            reason: String,
+            team_user_id: i64,
+            db: &C,
+        ) -> Result<crate::$entity::Model>
+        where
+            C: ConnectionTrait,
+        {
+            let mut active_model: crate::$entity::ActiveModel = model.into();
+            active_model.eligibility_override = ActiveValue::Set(classification);
+            active_model.eligibility_override_reason = ActiveValue::Set(Some(reason));
+            active_model.eligibility_override_by_team_user_id =
+                ActiveValue::Set(Some(team_user_id));
+            active_model.eligibility_override_at = ActiveValue::Set(Some(Utc::now().into()));
+            Ok(active_model.update(db).await?)
+        }
+    };
+}
+
+eligibility_writes!(
+    player,
+    set_player_nba_roster_status,
+    set_player_eligibility_override
+);
+eligibility_writes!(
+    league_player,
+    set_league_player_nba_roster_status,
+    set_league_player_eligibility_override
+);

--- a/entity/src/queries/eligibility_queries.rs
+++ b/entity/src/queries/eligibility_queries.rs
@@ -1,6 +1,6 @@
 //! Commissioner writes to the eligibility columns on `player` / `league_player` (spec 10).
 //!
-//! Two deliberately separate writes: the NBA-roster *fact* (which the feed also sets) and the
+//! Two deliberately separate writes: the NBA *facts* (which the feed also sets) and the
 //! commissioner's override of the *derived classification*. The pair is identical for both player
 //! tables, so one macro generates both.
 
@@ -12,17 +12,20 @@ use crate::player::{EligibilityClassification, NbaRosterSource};
 
 macro_rules! eligibility_writes {
     ($entity:ident, $set_fact:ident, $set_override:ident) => {
-        /// Corrects the NBA-roster fact, marking the commissioner as its source.
+        /// Corrects both NBA facts, marking the commissioner as their source.
         pub async fn $set_fact<C>(
             model: crate::$entity::Model,
-            has_been_on_nba_roster: bool,
+            has_played_nba_game: bool,
+            nba_first_season_end_of_season_year: Option<i16>,
             db: &C,
         ) -> Result<crate::$entity::Model>
         where
             C: ConnectionTrait,
         {
             let mut active_model: crate::$entity::ActiveModel = model.into();
-            active_model.has_been_on_nba_roster = ActiveValue::Set(has_been_on_nba_roster);
+            active_model.has_played_nba_game = ActiveValue::Set(has_played_nba_game);
+            active_model.nba_first_season_end_of_season_year =
+                ActiveValue::Set(nba_first_season_end_of_season_year);
             active_model.nba_roster_source =
                 ActiveValue::Set(NbaRosterSource::CommissionerOverride);
             active_model.nba_roster_asof = ActiveValue::Set(Some(Utc::now().into()));
@@ -53,11 +56,11 @@ macro_rules! eligibility_writes {
 
 eligibility_writes!(
     player,
-    set_player_nba_roster_status,
+    set_player_nba_status,
     set_player_eligibility_override
 );
 eligibility_writes!(
     league_player,
-    set_league_player_nba_roster_status,
+    set_league_player_nba_status,
     set_league_player_eligibility_override
 );

--- a/entity/src/queries/league_player_queries.rs
+++ b/entity/src/queries/league_player_queries.rs
@@ -27,6 +27,24 @@ where
     Ok(league_players_by_name)
 }
 
+/// Every league player in a league, name-ordered. Unlike `find_all_league_players_in_league` this
+/// keeps duplicates-by-name and preserves order, which the eligibility pools need.
+#[instrument]
+pub async fn find_league_players_in_league<C>(
+    league_id: i64,
+    db: &C,
+) -> Result<Vec<league_player::Model>>
+where
+    C: ConnectionTrait + Debug,
+{
+    let league_players = league_player::Entity::find()
+        .filter(league_player::Column::LeagueId.eq(league_id))
+        .order_by_asc(league_player::Column::Name)
+        .all(db)
+        .await?;
+    Ok(league_players)
+}
+
 /// Case- and accent-insensitive substring search on league player names, scoped to one league.
 #[instrument]
 pub async fn search_league_players_by_name<C>(

--- a/entity/src/queries/league_player_queries.rs
+++ b/entity/src/queries/league_player_queries.rs
@@ -1,5 +1,6 @@
 use std::{collections::HashMap, fmt::Debug};
 
+use chrono::Utc;
 use color_eyre::{Result, eyre::eyre};
 use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter,
@@ -93,6 +94,8 @@ where
         name: ActiveValue::Set(name),
         league_id: ActiveValue::Set(league_id),
         is_rdi_eligible: ActiveValue::Set(true),
+        // a league_player has no NBA index entry by definition; stamp when we last checked
+        nba_roster_asof: ActiveValue::Set(Some(Utc::now().into())),
         ..Default::default()
     };
     let inserted_league_player = league_player_to_insert.insert(db).await?;

--- a/entity/src/queries/mod.rs
+++ b/entity/src/queries/mod.rs
@@ -2,6 +2,7 @@ pub mod auction_queries;
 pub mod contract_queries;
 pub mod deadline_queries;
 pub mod draft_pick_queries;
+pub mod eligibility_queries;
 pub mod job_run_queries;
 pub mod league_player_queries;
 pub mod league_queries;

--- a/entity/src/queries/player_queries.rs
+++ b/entity/src/queries/player_queries.rs
@@ -57,6 +57,30 @@ where
     Ok(player_models)
 }
 
+/// Real players that could land in any eligibility pool (spec 10).
+///
+/// Currently-active players that either have NBA-roster history, carry the draft-eligible flag, or
+/// have a commissioner override. Everyone else classifies `Ineligible`, so filtering them in SQL
+/// keeps the whole all-seasons `player` table out of memory. Callers classify and filter roster
+/// status themselves.
+pub async fn find_eligibility_candidate_players<C>(db: &C) -> Result<Vec<player::Model>>
+where
+    C: ConnectionTrait,
+{
+    let players = player::Entity::find()
+        .filter(player::Column::Status.eq(player::PlayerStatus::Active))
+        .filter(
+            player::Column::HasBeenOnNbaRoster
+                .eq(true)
+                .or(player::Column::IsRdiEligible.eq(true))
+                .or(player::Column::EligibilityOverride.is_not_null()),
+        )
+        .order_by_asc(player::Column::Name)
+        .all(db)
+        .await?;
+    Ok(players)
+}
+
 /// Batch fetch for the GraphQL player `DataLoader`.
 pub async fn find_players_by_ids<C>(ids: Vec<i64>, db: &C) -> Result<Vec<player::Model>>
 where

--- a/entity/src/queries/player_queries.rs
+++ b/entity/src/queries/player_queries.rs
@@ -59,19 +59,23 @@ where
 
 /// Real players that could land in any eligibility pool (spec 10).
 ///
-/// Currently-active players that either have NBA-roster history, carry the draft-eligible flag, or
-/// have a commissioner override. Everyone else classifies `Ineligible`, so filtering them in SQL
-/// keeps the whole all-seasons `player` table out of memory. Callers classify and filter roster
-/// status themselves.
-pub async fn find_eligibility_candidate_players<C>(db: &C) -> Result<Vec<player::Model>>
+/// Currently-active players that could land in any eligibility pool for `end_of_season_year`: those
+/// already in NBA data by then, plus anyone carrying the draft-eligible flag or a commissioner
+/// override. Everyone else classifies `Ineligible` for that season, so filtering them in SQL keeps
+/// the whole all-seasons `player` table out of memory. Callers classify and filter roster status
+/// themselves.
+pub async fn find_eligibility_candidate_players<C>(
+    end_of_season_year: i16,
+    db: &C,
+) -> Result<Vec<player::Model>>
 where
     C: ConnectionTrait,
 {
     let players = player::Entity::find()
         .filter(player::Column::Status.eq(player::PlayerStatus::Active))
         .filter(
-            player::Column::HasBeenOnNbaRoster
-                .eq(true)
+            player::Column::NbaFirstSeasonEndOfSeasonYear
+                .lte(end_of_season_year)
                 .or(player::Column::IsRdiEligible.eq(true))
                 .or(player::Column::EligibilityOverride.is_not_null()),
         )

--- a/logic/CLAUDE.md
+++ b/logic/CLAUDE.md
@@ -43,9 +43,9 @@ values from there; do not duplicate literals into logic.
    should not build raw SeaORM statements. If a query is missing, add it to `entity`, not here.
 
 4. **Validate eligibility before mutating.** `drop_contract` and `ir` check `ContractStatus` /
-   `is_ir` first and `bail!`/`ensure!` on violation. Note: `rookie_development_activation` and
-   `rookie_development_international` currently *skip* this guard — that's a known inconsistency,
-   not a pattern to copy. Add guards to new mutators.
+   `is_ir` first and `bail!`/`ensure!` on violation. `rookie_development_activation` checks
+   kind/status/latest-in-chain, and `rookie_development_international` checks the source contract
+   kind plus (for RD → RDI only) `eligibility::validate_rdi_eligible`. Add guards to new mutators.
 
 5. **Contracts form a chain.** Mutations create a *new* contract record (previous/original ids
    linked) rather than editing in place. Validate "latest in chain" before acting on a contract

--- a/logic/CLAUDE.md
+++ b/logic/CLAUDE.md
@@ -21,6 +21,7 @@ values from there; do not duplicate literals into logic.
 | `deadline_processing/keeper_deadline/` | Validate + record team keepers at the keeper deadline. |
 | `deadline_processing/roster_lock/` | Validate rosters (IR/type/cap) and lock them at each lock deadline. |
 | `draft_picks/` | Generate future draft picks (rounds 1..=N, N seasons ahead). |
+| `eligibility/` | Classify players (auction vs rookie draft vs ineligible) and build the acquisition pools. |
 | `drop_contract/` | Drop a contract from a team; record dropped-contract cap penalty data. |
 | `ir/` | Move a contract to / activate from IR. |
 | `rookie_development_activation/` | Activate an RD/RDI contract into a rookie contract. |

--- a/logic/src/eligibility/classify.rs
+++ b/logic/src/eligibility/classify.rs
@@ -1,0 +1,116 @@
+//! Pure eligibility classifier (spec 10 / rules §3.1.2, §6.2.1, §7.5).
+//!
+//! Classification is never stored — only the commissioner override is. Everything else is derived
+//! from the current NBA-roster fact so a mid-cycle NBA signing (§11.3.1) flips the pool membership
+//! on the next read.
+
+use fbkl_entity::{
+    league_player,
+    player::{self, EligibilityClassification},
+};
+
+/// The minimal facts `classify_player` needs, so it stays DB-free and unit-testable.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct PlayerEligibilityFacts {
+    /// Rules §3.1.2 pivot: has the player ever been on an active NBA roster?
+    pub has_been_on_nba_roster: bool,
+    /// Commissioner override of the derived classification; wins when set.
+    pub eligibility_override: Option<EligibilityClassification>,
+    /// A league-created (drafted, not-yet-NBA) player.
+    pub is_league_player: bool,
+    /// The `is_rdi_eligible` cache — treated as a draft-eligible flag, correctable by validators.
+    pub is_flagged_draft_eligible: bool,
+}
+
+impl From<&player::Model> for PlayerEligibilityFacts {
+    fn from(model: &player::Model) -> Self {
+        Self {
+            has_been_on_nba_roster: model.has_been_on_nba_roster,
+            eligibility_override: model.eligibility_override,
+            is_league_player: false,
+            is_flagged_draft_eligible: model.is_rdi_eligible,
+        }
+    }
+}
+
+impl From<&league_player::Model> for PlayerEligibilityFacts {
+    fn from(model: &league_player::Model) -> Self {
+        Self {
+            has_been_on_nba_roster: model.has_been_on_nba_roster,
+            eligibility_override: model.eligibility_override,
+            is_league_player: true,
+            is_flagged_draft_eligible: model.is_rdi_eligible,
+        }
+    }
+}
+
+/// Derives which acquisition pool a player belongs to, in the spec's precedence order.
+#[must_use]
+pub const fn classify_player(facts: PlayerEligibilityFacts) -> EligibilityClassification {
+    if let Some(classification) = facts.eligibility_override {
+        return classification;
+    }
+    if facts.has_been_on_nba_roster {
+        return EligibilityClassification::VeteranAuctionEligible;
+    }
+    // §7.5.1 sub-categories aren't distinguishable from current data — see spec 12 for source tags.
+    if facts.is_league_player || facts.is_flagged_draft_eligible {
+        return EligibilityClassification::RookieDraftEligible;
+    }
+    EligibilityClassification::Ineligible
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PlayerEligibilityFacts, classify_player};
+    use fbkl_entity::player::EligibilityClassification::{
+        Ineligible, RookieDraftEligible, VeteranAuctionEligible,
+    };
+
+    #[test]
+    fn override_beats_derived_classification() {
+        let facts = PlayerEligibilityFacts {
+            has_been_on_nba_roster: true,
+            eligibility_override: Some(Ineligible),
+            ..PlayerEligibilityFacts::default()
+        };
+        assert_eq!(classify_player(facts), Ineligible);
+    }
+
+    #[test]
+    fn nba_roster_history_means_veteran_auction() {
+        let facts = PlayerEligibilityFacts {
+            has_been_on_nba_roster: true,
+            is_league_player: true,
+            is_flagged_draft_eligible: true,
+            ..PlayerEligibilityFacts::default()
+        };
+        assert_eq!(classify_player(facts), VeteranAuctionEligible);
+    }
+
+    #[test]
+    fn drafted_league_player_is_rookie_draft_eligible() {
+        let facts = PlayerEligibilityFacts {
+            is_league_player: true,
+            ..PlayerEligibilityFacts::default()
+        };
+        assert_eq!(classify_player(facts), RookieDraftEligible);
+    }
+
+    #[test]
+    fn flagged_draft_eligible_real_player_is_rookie_draft_eligible() {
+        let facts = PlayerEligibilityFacts {
+            is_flagged_draft_eligible: true,
+            ..PlayerEligibilityFacts::default()
+        };
+        assert_eq!(classify_player(facts), RookieDraftEligible);
+    }
+
+    #[test]
+    fn never_on_nba_roster_and_unflagged_is_ineligible() {
+        assert_eq!(
+            classify_player(PlayerEligibilityFacts::default()),
+            Ineligible
+        );
+    }
+}

--- a/logic/src/eligibility/classify.rs
+++ b/logic/src/eligibility/classify.rs
@@ -1,8 +1,13 @@
 //! Pure eligibility classifier (spec 10 / rules §3.1.2, §6.2.1, §7.5).
 //!
-//! Classification is never stored — only the commissioner override is. Everything else is derived
-//! from the current NBA-roster fact so a mid-cycle NBA signing (§11.3.1) flips the pool membership
-//! on the next read.
+//! Classification is never stored — only the commissioner override is — and it is always relative to
+//! a **season**, never to "now". The same player is rookie-draft-eligible the season before his NBA
+//! debut and a veteran the season after, so every caller states which season it is asking about:
+//! pool builders pass the pool's season, contract guards pass the contract's, and historical replay
+//! therefore gets the answer that was true at the time.
+//!
+//! Pool membership pivots on games played (§3.1.2); the broader "was on an NBA roster" (§3.1.3) only
+//! gates RDI — see `super::rdi`.
 
 use fbkl_entity::{
     league_player,
@@ -12,8 +17,11 @@ use fbkl_entity::{
 /// The minimal facts `classify_player` needs, so it stays DB-free and unit-testable.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct PlayerEligibilityFacts {
-    /// Rules §3.1.2 pivot: has the player ever been on an active NBA roster?
-    pub has_been_on_nba_roster: bool,
+    /// Whether the player ever appeared in an in-season NBA game, over his whole career.
+    pub has_played_nba_game: bool,
+    /// The season the player first appeared in NBA data, if he ever did. Turns the two career facts
+    /// above and below into as-of-a-season answers.
+    pub nba_first_season_end_of_season_year: Option<i16>,
     /// Commissioner override of the derived classification; wins when set.
     pub eligibility_override: Option<EligibilityClassification>,
     /// A league-created (drafted, not-yet-NBA) player.
@@ -22,10 +30,38 @@ pub struct PlayerEligibilityFacts {
     pub is_flagged_draft_eligible: bool,
 }
 
+impl PlayerEligibilityFacts {
+    /// Rules §3.1.3 entering a season: had the player any NBA entry in an *earlier* season?
+    ///
+    /// Strictly earlier, not same-or-earlier, because the stored season is only season-granular
+    /// while the rules turn on where in the season the player arrived. §11.3.5 gives an RDI who
+    /// lands on an NBA roster mid-season until the *next* legalization to move, and a mid-season
+    /// signing or a draft-and-stash both record the season they arrived in — so `<=` would reject
+    /// exactly the legalization the rule protects.
+    #[must_use]
+    pub const fn was_on_nba_roster_before(&self, end_of_season_year: i16) -> bool {
+        match self.nba_first_season_end_of_season_year {
+            Some(first_season) => first_season < end_of_season_year,
+            None => false,
+        }
+    }
+
+    /// Rules §3.1.2 entering a season: had the player appeared in a game in an earlier season?
+    ///
+    /// The stored `has_played_nba_game` is a career fact with no date of its own, so his first NBA
+    /// season stands in for his debut. A player rostered seasons before he first appeared reads as
+    /// having debuted too early; the commissioner override settles those.
+    #[must_use]
+    pub const fn had_played_nba_game_before(&self, end_of_season_year: i16) -> bool {
+        self.has_played_nba_game && self.was_on_nba_roster_before(end_of_season_year)
+    }
+}
+
 impl From<&player::Model> for PlayerEligibilityFacts {
     fn from(model: &player::Model) -> Self {
         Self {
-            has_been_on_nba_roster: model.has_been_on_nba_roster,
+            has_played_nba_game: model.has_played_nba_game,
+            nba_first_season_end_of_season_year: model.nba_first_season_end_of_season_year,
             eligibility_override: model.eligibility_override,
             is_league_player: false,
             is_flagged_draft_eligible: model.is_rdi_eligible,
@@ -36,7 +72,8 @@ impl From<&player::Model> for PlayerEligibilityFacts {
 impl From<&league_player::Model> for PlayerEligibilityFacts {
     fn from(model: &league_player::Model) -> Self {
         Self {
-            has_been_on_nba_roster: model.has_been_on_nba_roster,
+            has_played_nba_game: model.has_played_nba_game,
+            nba_first_season_end_of_season_year: model.nba_first_season_end_of_season_year,
             eligibility_override: model.eligibility_override,
             is_league_player: true,
             is_flagged_draft_eligible: model.is_rdi_eligible,
@@ -44,13 +81,20 @@ impl From<&league_player::Model> for PlayerEligibilityFacts {
     }
 }
 
-/// Derives which acquisition pool a player belongs to, in the spec's precedence order.
+/// Derives which acquisition pool a player belongs to entering `end_of_season_year`.
+///
+/// Follows the spec's precedence order. A player who debuts during that season is still
+/// draft-eligible for it and becomes a veteran for the next one, matching when the auction and
+/// draft actually run.
 #[must_use]
-pub const fn classify_player(facts: PlayerEligibilityFacts) -> EligibilityClassification {
+pub const fn classify_player(
+    facts: PlayerEligibilityFacts,
+    end_of_season_year: i16,
+) -> EligibilityClassification {
     if let Some(classification) = facts.eligibility_override {
         return classification;
     }
-    if facts.has_been_on_nba_roster {
+    if facts.had_played_nba_game_before(end_of_season_year) {
         return EligibilityClassification::VeteranAuctionEligible;
     }
     // §7.5.1 sub-categories aren't distinguishable from current data — see spec 12 for source tags.
@@ -70,22 +114,55 @@ mod tests {
     #[test]
     fn override_beats_derived_classification() {
         let facts = PlayerEligibilityFacts {
-            has_been_on_nba_roster: true,
+            has_played_nba_game: true,
+            nba_first_season_end_of_season_year: Some(2020),
             eligibility_override: Some(Ineligible),
             ..PlayerEligibilityFacts::default()
         };
-        assert_eq!(classify_player(facts), Ineligible);
+        assert_eq!(classify_player(facts, 2025), Ineligible);
     }
 
     #[test]
-    fn nba_roster_history_means_veteran_auction() {
+    fn nba_game_history_means_veteran_auction() {
         let facts = PlayerEligibilityFacts {
-            has_been_on_nba_roster: true,
+            has_played_nba_game: true,
+            nba_first_season_end_of_season_year: Some(2020),
             is_league_player: true,
             is_flagged_draft_eligible: true,
             ..PlayerEligibilityFacts::default()
         };
-        assert_eq!(classify_player(facts), VeteranAuctionEligible);
+        assert_eq!(classify_player(facts, 2025), VeteranAuctionEligible);
+    }
+
+    /// §3.1.2 — a rostered player who never appeared in a game stays in the rookie draft pool.
+    #[test]
+    fn nba_roster_without_a_game_is_still_rookie_draft_eligible() {
+        let facts = PlayerEligibilityFacts {
+            nba_first_season_end_of_season_year: Some(2020),
+            is_flagged_draft_eligible: true,
+            ..PlayerEligibilityFacts::default()
+        };
+        assert_eq!(classify_player(facts, 2025), RookieDraftEligible);
+    }
+
+    /// Leandro Bolmaro: drafted 2020, overseas for 2021, first NBA season 2022. One set of stored
+    /// facts answers all three seasons differently, which is the whole point of the season argument.
+    #[test]
+    fn classification_is_relative_to_the_season_asked_about() {
+        let facts = PlayerEligibilityFacts {
+            has_played_nba_game: true,
+            nba_first_season_end_of_season_year: Some(2022),
+            is_flagged_draft_eligible: true,
+            ..PlayerEligibilityFacts::default()
+        };
+
+        assert_eq!(classify_player(facts, 2021), RookieDraftEligible);
+        assert!(!facts.was_on_nba_roster_before(2021));
+        // §11.3.5 — arriving during 2022 does not retroactively bar 2022's RD→RDI move.
+        assert_eq!(classify_player(facts, 2022), RookieDraftEligible);
+        assert!(!facts.was_on_nba_roster_before(2022));
+        assert_eq!(classify_player(facts, 2023), VeteranAuctionEligible);
+        assert!(facts.was_on_nba_roster_before(2023));
     }
 
     #[test]
@@ -94,7 +171,7 @@ mod tests {
             is_league_player: true,
             ..PlayerEligibilityFacts::default()
         };
-        assert_eq!(classify_player(facts), RookieDraftEligible);
+        assert_eq!(classify_player(facts, 2025), RookieDraftEligible);
     }
 
     #[test]
@@ -103,13 +180,13 @@ mod tests {
             is_flagged_draft_eligible: true,
             ..PlayerEligibilityFacts::default()
         };
-        assert_eq!(classify_player(facts), RookieDraftEligible);
+        assert_eq!(classify_player(facts, 2025), RookieDraftEligible);
     }
 
     #[test]
-    fn never_on_nba_roster_and_unflagged_is_ineligible() {
+    fn never_played_and_unflagged_is_ineligible() {
         assert_eq!(
-            classify_player(PlayerEligibilityFacts::default()),
+            classify_player(PlayerEligibilityFacts::default(), 2025),
             Ineligible
         );
     }

--- a/logic/src/eligibility/mod.rs
+++ b/logic/src/eligibility/mod.rs
@@ -1,0 +1,6 @@
+//! Player eligibility: which acquisition pool (veteran auction / rookie draft / neither) a player
+//! belongs to, per spec 10.
+
+mod classify;
+
+pub use classify::{PlayerEligibilityFacts, classify_player};

--- a/logic/src/eligibility/mod.rs
+++ b/logic/src/eligibility/mod.rs
@@ -2,5 +2,10 @@
 //! belongs to, per spec 10.
 
 mod classify;
+mod pools;
 
 pub use classify::{PlayerEligibilityFacts, classify_player};
+pub use pools::{
+    VeteranAuctionPool, build_in_season_fa_pool, build_rookie_draft_eligible_pool,
+    build_veteran_auction_pool,
+};

--- a/logic/src/eligibility/mod.rs
+++ b/logic/src/eligibility/mod.rs
@@ -3,9 +3,11 @@
 
 mod classify;
 mod pools;
+mod rdi;
 
 pub use classify::{PlayerEligibilityFacts, classify_player};
 pub use pools::{
     VeteranAuctionPool, build_in_season_fa_pool, build_rookie_draft_eligible_pool,
     build_veteran_auction_pool,
 };
+pub use rdi::validate_rdi_eligible;

--- a/logic/src/eligibility/pools.rs
+++ b/logic/src/eligibility/pools.rs
@@ -1,0 +1,296 @@
+//! Eligibility pool membership (spec 10 / rules §6.2, §7.5, §8.4).
+//!
+//! All three pools are the same two-step read: classify every candidate player, then subtract the
+//! players a team currently rosters. Nothing keys off historical contract rows — §7.5.3 is explicit
+//! that prior league draft/ownership never affects eligibility, so a previously-drafted,
+//! now-unrostered, never-NBA player is still in the rookie draft pool.
+//!
+//! Membership only. Minimum bids and the auction schedule belong to spec 01.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Debug,
+};
+
+use color_eyre::Result;
+use fbkl_entity::{
+    contract::{self, ContractKind, RelatedPlayer},
+    contract_queries, league_player_queries,
+    player::EligibilityClassification,
+    player_queries,
+    sea_orm::ConnectionTrait,
+};
+use tracing::instrument;
+
+use super::{PlayerEligibilityFacts, classify_player};
+
+/// Identifies a pool member the same way a contract does: a real NBA player or a league-created one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum PlayerRef {
+    Player(i64),
+    LeaguePlayer(i64),
+}
+
+/// §6.2.2 — the veteran auction pool is not one flat list; RFAs are auctioned in the first week only
+/// and their original owner may not bid, so consumers need the split.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct VeteranAuctionPool {
+    pub restricted_free_agents: Vec<RelatedPlayer>,
+    pub unrestricted_free_agents: Vec<RelatedPlayer>,
+    pub free_agents: Vec<RelatedPlayer>,
+}
+
+/// Which §6.2.2 bucket an unrostered player's current contract kind puts them in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FreeAgencyBucket {
+    Restricted,
+    Unrestricted,
+    FreeAgent,
+}
+
+/// No active contract means never-owned or long-expired, which is a plain free agent.
+const fn free_agency_bucket(maybe_kind: Option<ContractKind>) -> FreeAgencyBucket {
+    match maybe_kind {
+        Some(ContractKind::RestrictedFreeAgent) => FreeAgencyBucket::Restricted,
+        Some(
+            ContractKind::UnrestrictedFreeAgentOriginalTeam
+            | ContractKind::UnrestrictedFreeAgentVeteran,
+        ) => FreeAgencyBucket::Unrestricted,
+        _ => FreeAgencyBucket::FreeAgent,
+    }
+}
+
+/// The league's current roster + free-agency picture for one season.
+#[derive(Debug, Default)]
+struct RosterSnapshot {
+    /// Players a team currently holds — keepers and already-acquired players.
+    rostered: HashSet<PlayerRef>,
+    /// Contract kind of unrostered players, which drives the §6.2.2 partition.
+    free_agent_kinds: HashMap<PlayerRef, ContractKind>,
+}
+
+impl RosterSnapshot {
+    /// A contract can name a real player, a league player, or (after a league player is linked to an
+    /// NBA entry) effectively both, so every id present is recorded.
+    fn from_contracts(contracts: &[contract::Model]) -> Self {
+        let mut snapshot = Self::default();
+        for contract_model in contracts {
+            let refs = [
+                contract_model.player_id.map(PlayerRef::Player),
+                contract_model.league_player_id.map(PlayerRef::LeaguePlayer),
+            ];
+            for player_ref in refs.into_iter().flatten() {
+                if contract_model.team_id.is_some() {
+                    snapshot.rostered.insert(player_ref);
+                } else {
+                    snapshot
+                        .free_agent_kinds
+                        .insert(player_ref, contract_model.kind);
+                }
+            }
+        }
+        snapshot
+    }
+}
+
+/// Candidate players classified into one of `allowed` and not currently rostered.
+#[instrument(skip(db))]
+async fn build_pool<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    allowed: &[EligibilityClassification],
+    db: &C,
+) -> Result<(Vec<(PlayerRef, RelatedPlayer)>, RosterSnapshot)>
+where
+    C: ConnectionTrait + Debug,
+{
+    let contracts = contract_queries::find_active_contracts_in_league_for_season(
+        league_id,
+        end_of_season_year,
+        db,
+    )
+    .await?;
+    let snapshot = RosterSnapshot::from_contracts(&contracts);
+
+    let players = player_queries::find_eligibility_candidate_players(db).await?;
+    let league_players =
+        league_player_queries::find_league_players_in_league(league_id, db).await?;
+
+    let candidates = players
+        .into_iter()
+        .map(|model| {
+            (
+                PlayerRef::Player(model.id),
+                PlayerEligibilityFacts::from(&model),
+                RelatedPlayer::Player(model),
+            )
+        })
+        // A linked league player duplicates its real-player row; the real row wins.
+        .chain(
+            league_players
+                .into_iter()
+                .filter(|model| model.real_player_id.is_none())
+                .map(|model| {
+                    (
+                        PlayerRef::LeaguePlayer(model.id),
+                        PlayerEligibilityFacts::from(&model),
+                        RelatedPlayer::LeaguePlayer(model),
+                    )
+                }),
+        );
+
+    let members = candidates
+        .filter(|(player_ref, facts, _)| {
+            allowed.contains(&classify_player(*facts)) && !snapshot.rostered.contains(player_ref)
+        })
+        .map(|(player_ref, _, related_player)| (player_ref, related_player))
+        .collect();
+
+    Ok((members, snapshot))
+}
+
+/// §6.2.1 — every player who has been on an active NBA roster and is not a keeper, split per §6.2.2.
+#[instrument(skip(db))]
+pub async fn build_veteran_auction_pool<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    db: &C,
+) -> Result<VeteranAuctionPool>
+where
+    C: ConnectionTrait + Debug,
+{
+    let (members, snapshot) = build_pool(
+        league_id,
+        end_of_season_year,
+        &[EligibilityClassification::VeteranAuctionEligible],
+        db,
+    )
+    .await?;
+
+    let mut pool = VeteranAuctionPool::default();
+    for (player_ref, related_player) in members {
+        let bucket = free_agency_bucket(snapshot.free_agent_kinds.get(&player_ref).copied());
+        match bucket {
+            FreeAgencyBucket::Restricted => pool.restricted_free_agents.push(related_player),
+            FreeAgencyBucket::Unrestricted => pool.unrestricted_free_agents.push(related_player),
+            FreeAgencyBucket::FreeAgent => pool.free_agents.push(related_player),
+        }
+    }
+    Ok(pool)
+}
+
+/// §7.5 — never-NBA players in the draft-eligible set who are not currently rostered.
+#[instrument(skip(db))]
+pub async fn build_rookie_draft_eligible_pool<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    db: &C,
+) -> Result<Vec<RelatedPlayer>>
+where
+    C: ConnectionTrait + Debug,
+{
+    let (members, _) = build_pool(
+        league_id,
+        end_of_season_year,
+        &[EligibilityClassification::RookieDraftEligible],
+        db,
+    )
+    .await?;
+    Ok(members.into_iter().map(|(_, player)| player).collect())
+}
+
+/// §8.4 — the union of the auction and draft pools minus currently-rostered players. `Ineligible`
+/// players stay out (§8.4.2).
+#[instrument(skip(db))]
+pub async fn build_in_season_fa_pool<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    db: &C,
+) -> Result<Vec<RelatedPlayer>>
+where
+    C: ConnectionTrait + Debug,
+{
+    let (members, _) = build_pool(
+        league_id,
+        end_of_season_year,
+        &[
+            EligibilityClassification::VeteranAuctionEligible,
+            EligibilityClassification::RookieDraftEligible,
+        ],
+        db,
+    )
+    .await?;
+    Ok(members.into_iter().map(|(_, player)| player).collect())
+}
+
+#[cfg(test)]
+mod tests {
+    use fbkl_entity::contract::{ContractKind, ContractStatus};
+
+    use super::{FreeAgencyBucket, PlayerRef, RosterSnapshot, free_agency_bucket};
+
+    fn contract(
+        player_id: i64,
+        team_id: Option<i64>,
+        kind: ContractKind,
+    ) -> fbkl_entity::contract::Model {
+        fbkl_entity::contract::Model {
+            id: player_id,
+            year_number: 1,
+            kind,
+            is_ir: false,
+            salary: 10,
+            end_of_season_year: 2025,
+            status: ContractStatus::Active,
+            league_id: 1,
+            league_player_id: None,
+            player_id: Some(player_id),
+            previous_contract_id: None,
+            original_contract_id: Some(player_id),
+            team_id,
+            created_at: chrono::Utc::now().into(),
+            updated_at: chrono::Utc::now().into(),
+        }
+    }
+
+    #[test]
+    fn snapshot_separates_rostered_from_free_agents() {
+        let snapshot = RosterSnapshot::from_contracts(&[
+            contract(1, Some(7), ContractKind::Veteran),
+            contract(2, None, ContractKind::RestrictedFreeAgent),
+        ]);
+
+        assert!(snapshot.rostered.contains(&PlayerRef::Player(1)));
+        assert!(!snapshot.rostered.contains(&PlayerRef::Player(2)));
+        assert_eq!(
+            snapshot.free_agent_kinds.get(&PlayerRef::Player(2)),
+            Some(&ContractKind::RestrictedFreeAgent)
+        );
+        assert!(
+            !snapshot
+                .free_agent_kinds
+                .contains_key(&PlayerRef::Player(1))
+        );
+    }
+
+    #[test]
+    fn free_agency_buckets_follow_contract_kind() {
+        assert_eq!(
+            free_agency_bucket(Some(ContractKind::RestrictedFreeAgent)),
+            FreeAgencyBucket::Restricted
+        );
+        assert_eq!(
+            free_agency_bucket(Some(ContractKind::UnrestrictedFreeAgentOriginalTeam)),
+            FreeAgencyBucket::Unrestricted
+        );
+        assert_eq!(
+            free_agency_bucket(Some(ContractKind::UnrestrictedFreeAgentVeteran)),
+            FreeAgencyBucket::Unrestricted
+        );
+        assert_eq!(
+            free_agency_bucket(Some(ContractKind::FreeAgent)),
+            FreeAgencyBucket::FreeAgent
+        );
+        assert_eq!(free_agency_bucket(None), FreeAgencyBucket::FreeAgent);
+    }
+}

--- a/logic/src/eligibility/pools.rs
+++ b/logic/src/eligibility/pools.rs
@@ -1,9 +1,10 @@
 //! Eligibility pool membership (spec 10 / rules §6.2, §7.5, §8.4).
 //!
-//! All three pools are the same two-step read: classify every candidate player, then subtract the
-//! players a team currently rosters. Nothing keys off historical contract rows — §7.5.3 is explicit
+//! All three pools are the same two-step read: classify every candidate player *as of the pool's
+//! season*, then subtract the players a team currently rosters. Asking for a past season therefore
+//! yields that season's pool, not today's. Nothing keys off historical contract rows — §7.5.3 is explicit
 //! that prior league draft/ownership never affects eligibility, so a previously-drafted,
-//! now-unrostered, never-NBA player is still in the rookie draft pool.
+//! now-unrostered player who has never played an NBA game is still in the rookie draft pool.
 //!
 //! Membership only. Minimum bids and the auction schedule belong to spec 01.
 
@@ -112,7 +113,8 @@ where
     .await?;
     let snapshot = RosterSnapshot::from_contracts(&contracts);
 
-    let players = player_queries::find_eligibility_candidate_players(db).await?;
+    let players =
+        player_queries::find_eligibility_candidate_players(end_of_season_year, db).await?;
     let league_players =
         league_player_queries::find_league_players_in_league(league_id, db).await?;
 
@@ -141,7 +143,8 @@ where
 
     let members = candidates
         .filter(|(player_ref, facts, _)| {
-            allowed.contains(&classify_player(*facts)) && !snapshot.rostered.contains(player_ref)
+            allowed.contains(&classify_player(*facts, end_of_season_year))
+                && !snapshot.rostered.contains(player_ref)
         })
         .map(|(player_ref, _, related_player)| (player_ref, related_player))
         .collect();
@@ -149,7 +152,7 @@ where
     Ok((members, snapshot))
 }
 
-/// §6.2.1 — every player who has been on an active NBA roster and is not a keeper, split per §6.2.2.
+/// §6.2.1 — every player who has played in an NBA game and is not a keeper, split per §6.2.2.
 #[instrument(skip(db))]
 pub async fn build_veteran_auction_pool<C>(
     league_id: i64,
@@ -179,7 +182,7 @@ where
     Ok(pool)
 }
 
-/// §7.5 — never-NBA players in the draft-eligible set who are not currently rostered.
+/// §7.5 — never-played-an-NBA-game players in the draft-eligible set who are not currently rostered.
 #[instrument(skip(db))]
 pub async fn build_rookie_draft_eligible_pool<C>(
     league_id: i64,

--- a/logic/src/eligibility/rdi.rs
+++ b/logic/src/eligibility/rdi.rs
@@ -2,6 +2,13 @@
 //!
 //! Gates RD → RDI moves. The `is_rdi_eligible` bool on `player`/`league_player` is a cache this
 //! validator can correct, so it is deliberately not an input here — callers pass the derived facts.
+//!
+//! RDI keys off the broader §3.1.3 "was on an NBA roster" fact, not the §3.1.2 pool pivot: §11.3.1
+//! forces RDI→RD/1 the moment a player is "on an NBA roster / signed to an NBA contract", so a
+//! rostered player who never appeared in a game is still rookie-draft-eligible yet already
+//! RDI-ineligible. Both are asked as of the contract's own season, so replaying a 2021 RD→RDI move
+//! is judged on what was true entering 2021, not on the player's career to date. §11.3.5's
+//! mid-season grace period is why "before the season" is strict — see `was_on_nba_roster_before`.
 
 use std::fmt::Debug;
 
@@ -18,8 +25,9 @@ use super::{PlayerEligibilityFacts, classify_player};
 
 /// Validates that a contract's player may move to Rookie Development International.
 ///
-/// Rules §11.3.1: the player must be rookie-draft-eligible, must never have been on an NBA roster,
-/// and must not have already been an RD contract at/after an in-season roster legalization.
+/// Rules §11.3.1, judged entering the contract's season: the player must be rookie-draft-eligible,
+/// must not have been on an NBA roster in an earlier season (broader than the pool pivot — see the
+/// module docs), and must not have already been an RD contract at/after an in-season legalization.
 #[instrument]
 pub async fn validate_rdi_eligible<C>(
     contract_model: &contract::Model,
@@ -29,14 +37,15 @@ pub async fn validate_rdi_eligible<C>(
 where
     C: ConnectionTrait + Debug,
 {
+    let season = contract_model.end_of_season_year;
     ensure!(
-        classify_player(player_facts) == EligibilityClassification::RookieDraftEligible,
-        "Contract (id = {}) player is not rookie-draft-eligible, so cannot move to RDI.",
+        classify_player(player_facts, season) == EligibilityClassification::RookieDraftEligible,
+        "Contract (id = {}) player was not rookie-draft-eligible in {season}, so cannot move to RDI.",
         contract_model.id
     );
     ensure!(
-        !player_facts.has_been_on_nba_roster,
-        "Contract (id = {}) player has been on an NBA roster, so cannot move to RDI.",
+        !player_facts.was_on_nba_roster_before(season),
+        "Contract (id = {}) player was on an NBA roster before {season}, so cannot move to RDI.",
         contract_model.id
     );
 

--- a/logic/src/eligibility/rdi.rs
+++ b/logic/src/eligibility/rdi.rs
@@ -1,0 +1,127 @@
+//! RDI eligibility validator (rules §11.3.1).
+//!
+//! Gates RD → RDI moves. The `is_rdi_eligible` bool on `player`/`league_player` is a cache this
+//! validator can correct, so it is deliberately not an input here — callers pass the derived facts.
+
+use std::fmt::Debug;
+
+use color_eyre::eyre::{Result, ensure};
+use fbkl_entity::{
+    contract::{self, ContractKind},
+    contract_queries,
+    player::EligibilityClassification,
+    sea_orm::ConnectionTrait,
+};
+use tracing::instrument;
+
+use super::{PlayerEligibilityFacts, classify_player};
+
+/// Validates that a contract's player may move to Rookie Development International.
+///
+/// Rules §11.3.1: the player must be rookie-draft-eligible, must never have been on an NBA roster,
+/// and must not have already been an RD contract at/after an in-season roster legalization.
+#[instrument]
+pub async fn validate_rdi_eligible<C>(
+    contract_model: &contract::Model,
+    player_facts: PlayerEligibilityFacts,
+    db: &C,
+) -> Result<()>
+where
+    C: ConnectionTrait + Debug,
+{
+    ensure!(
+        classify_player(player_facts) == EligibilityClassification::RookieDraftEligible,
+        "Contract (id = {}) player is not rookie-draft-eligible, so cannot move to RDI.",
+        contract_model.id
+    );
+    ensure!(
+        !player_facts.has_been_on_nba_roster,
+        "Contract (id = {}) player has been on an NBA roster, so cannot move to RDI.",
+        contract_model.id
+    );
+
+    let chain = contract_queries::find_contract_chain(contract_model.id, db).await?;
+    ensure!(
+        !has_legalized_rd_ancestor(&chain, contract_model.end_of_season_year),
+        "Contract (id = {}) was already a post-legalization RD contract, so cannot move to RDI.",
+        contract_model.id
+    );
+
+    Ok(())
+}
+
+/// Proxy for "was RD at/after an in-season roster legalization": an RD contract past year 1, or an
+/// RD contract from an earlier season (which necessarily crossed that season's legalization).
+fn has_legalized_rd_ancestor(chain: &[contract::Model], end_of_season_year: i16) -> bool {
+    chain.iter().any(|chain_contract| {
+        chain_contract.kind == ContractKind::RookieDevelopment
+            && (chain_contract.year_number > 1
+                || chain_contract.end_of_season_year < end_of_season_year)
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use fbkl_entity::contract::{ContractKind, ContractStatus};
+
+    use super::has_legalized_rd_ancestor;
+
+    fn contract(
+        id: i64,
+        kind: ContractKind,
+        year_number: i16,
+        end_of_season_year: i16,
+    ) -> fbkl_entity::contract::Model {
+        fbkl_entity::contract::Model {
+            id,
+            year_number,
+            kind,
+            is_ir: false,
+            salary: 10,
+            end_of_season_year,
+            status: ContractStatus::Active,
+            league_id: 1,
+            league_player_id: None,
+            player_id: Some(1),
+            previous_contract_id: None,
+            original_contract_id: Some(1),
+            team_id: Some(7),
+            created_at: chrono::Utc::now().into(),
+            updated_at: chrono::Utc::now().into(),
+        }
+    }
+
+    #[test]
+    fn fresh_rd_year_one_chain_is_allowed() {
+        let chain = [contract(1, ContractKind::RookieDevelopment, 1, 2025)];
+
+        assert!(!has_legalized_rd_ancestor(&chain, 2025));
+    }
+
+    #[test]
+    fn rd_ancestor_from_earlier_season_is_rejected() {
+        let chain = [
+            contract(1, ContractKind::RookieDevelopment, 1, 2024),
+            contract(2, ContractKind::RookieDevelopment, 1, 2025),
+        ];
+
+        assert!(has_legalized_rd_ancestor(&chain, 2025));
+    }
+
+    #[test]
+    fn rd_past_year_one_is_rejected() {
+        let chain = [contract(1, ContractKind::RookieDevelopment, 2, 2025)];
+
+        assert!(has_legalized_rd_ancestor(&chain, 2025));
+    }
+
+    #[test]
+    fn non_rd_ancestors_are_ignored() {
+        let chain = [
+            contract(1, ContractKind::Rookie, 2, 2024),
+            contract(2, ContractKind::RookieDevelopment, 1, 2025),
+        ];
+
+        assert!(!has_legalized_rd_ancestor(&chain, 2025));
+    }
+}

--- a/logic/src/lib.rs
+++ b/logic/src/lib.rs
@@ -3,6 +3,7 @@ pub mod auction;
 pub mod deadline_processing;
 pub mod draft_picks;
 pub mod drop_contract;
+pub mod eligibility;
 pub mod ir;
 pub mod rookie_development_activation;
 pub mod rookie_development_international;

--- a/logic/src/rookie_development_activation/activate_rookie.rs
+++ b/logic/src/rookie_development_activation/activate_rookie.rs
@@ -1,8 +1,9 @@
 use std::fmt::Debug;
 
-use color_eyre::eyre::{Result, eyre};
+use color_eyre::eyre::{Result, ensure, eyre};
 use fbkl_entity::{
-    contract, contract_queries, deadline,
+    contract::{self, ContractKind, ContractStatus},
+    contract_queries, deadline,
     sea_orm::{ActiveValue, ConnectionTrait},
     transaction::{self, TransactionKind},
     transaction_queries,
@@ -22,6 +23,9 @@ pub async fn activate_rookie_development_contract<C>(
 where
     C: ConnectionTrait + Debug,
 {
+    validate_contract_is_activatable(&contract_model)?;
+    contract_queries::validate_contract_is_latest_in_chain(&contract_model, db).await?;
+
     let team_model = contract_model.get_team(db).await?.ok_or_else(|| {
         eyre!(
             "Could not retrieve the expected team for a RD(I) contract with id: {}",
@@ -60,4 +64,78 @@ where
     .await?;
 
     Ok(activated_contract)
+}
+
+/// Guards activation against non-RD(I) or stale contracts.
+fn validate_contract_is_activatable(contract_model: &contract::Model) -> Result<()> {
+    ensure!(
+        matches!(
+            contract_model.kind,
+            ContractKind::RookieDevelopment | ContractKind::RookieDevelopmentInternational
+        ),
+        "Contract (id = {}) is a {:?} contract, so it cannot be activated as a rookie contract.",
+        contract_model.id,
+        contract_model.kind
+    );
+    ensure!(
+        contract_model.status == ContractStatus::Active,
+        "Contract (id = {}) has status {:?}, so it cannot be activated.",
+        contract_model.id,
+        contract_model.status
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use fbkl_entity::contract::{ContractKind, ContractStatus, Model};
+
+    use super::validate_contract_is_activatable;
+
+    fn contract(kind: ContractKind, status: ContractStatus) -> Model {
+        Model {
+            id: 1,
+            year_number: 1,
+            kind,
+            is_ir: false,
+            salary: 10,
+            end_of_season_year: 2025,
+            status,
+            league_id: 1,
+            league_player_id: None,
+            player_id: Some(1),
+            previous_contract_id: None,
+            original_contract_id: Some(1),
+            team_id: Some(7),
+            created_at: chrono::Utc::now().into(),
+            updated_at: chrono::Utc::now().into(),
+        }
+    }
+
+    #[test]
+    fn non_rookie_development_kind_is_rejected() {
+        let contract_model = contract(ContractKind::Veteran, ContractStatus::Active);
+
+        assert!(validate_contract_is_activatable(&contract_model).is_err());
+    }
+
+    #[test]
+    fn replaced_contract_is_rejected() {
+        let contract_model = contract(ContractKind::RookieDevelopment, ContractStatus::Replaced);
+
+        assert!(validate_contract_is_activatable(&contract_model).is_err());
+    }
+
+    #[test]
+    fn active_rd_and_rdi_are_accepted() {
+        for kind in [
+            ContractKind::RookieDevelopment,
+            ContractKind::RookieDevelopmentInternational,
+        ] {
+            assert!(
+                validate_contract_is_activatable(&contract(kind, ContractStatus::Active)).is_ok()
+            );
+        }
+    }
 }

--- a/logic/src/rookie_development_international/mod.rs
+++ b/logic/src/rookie_development_international/mod.rs
@@ -4,3 +4,77 @@ mod rdi_team_update;
 
 pub use move_rd_contract_to_international::*;
 pub use move_rdi_contract_from_international::*;
+
+use color_eyre::eyre::{Result, ensure};
+use fbkl_entity::contract::{self, ContractKind};
+
+/// Guards an RD↔RDI move against being applied to the wrong contract kind (rules §11.3.1).
+fn validate_contract_kind(contract_model: &contract::Model, expected: ContractKind) -> Result<()> {
+    ensure!(
+        contract_model.kind == expected,
+        "Contract (id = {}) is a {:?} contract, but this move requires a {:?} contract.",
+        contract_model.id,
+        contract_model.kind,
+        expected
+    );
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use fbkl_entity::contract::{ContractKind, ContractStatus, Model};
+
+    use super::validate_contract_kind;
+
+    fn contract(kind: ContractKind) -> Model {
+        Model {
+            id: 1,
+            year_number: 1,
+            kind,
+            is_ir: false,
+            salary: 10,
+            end_of_season_year: 2025,
+            status: ContractStatus::Active,
+            league_id: 1,
+            league_player_id: None,
+            player_id: Some(1),
+            previous_contract_id: None,
+            original_contract_id: Some(1),
+            team_id: Some(7),
+            created_at: chrono::Utc::now().into(),
+            updated_at: chrono::Utc::now().into(),
+        }
+    }
+
+    #[test]
+    fn already_rdi_cannot_move_to_rdi() {
+        let contract_model = contract(ContractKind::RookieDevelopmentInternational);
+
+        assert!(
+            validate_contract_kind(&contract_model, ContractKind::RookieDevelopment).is_err(),
+            "an RDI contract must not pass the RD → RDI guard"
+        );
+    }
+
+    #[test]
+    fn veteran_cannot_move_out_of_rdi() {
+        let contract_model = contract(ContractKind::Veteran);
+
+        assert!(
+            validate_contract_kind(
+                &contract_model,
+                ContractKind::RookieDevelopmentInternational
+            )
+            .is_err(),
+            "a veteran contract must not pass the RDI → RD guard"
+        );
+    }
+
+    #[test]
+    fn matching_kind_passes() {
+        let contract_model = contract(ContractKind::RookieDevelopment);
+
+        assert!(validate_contract_kind(&contract_model, ContractKind::RookieDevelopment).is_ok());
+    }
+}

--- a/logic/src/rookie_development_international/move_rd_contract_to_international.rs
+++ b/logic/src/rookie_development_international/move_rd_contract_to_international.rs
@@ -2,7 +2,8 @@ use std::fmt::Debug;
 
 use color_eyre::eyre::{Result, eyre};
 use fbkl_entity::{
-    contract, contract_queries, deadline,
+    contract::{self, ContractKind, RelatedPlayer},
+    contract_queries, deadline,
     sea_orm::{ActiveValue, ConnectionTrait},
     team_update::ContractUpdateType,
     transaction::{self, TransactionKind},
@@ -10,7 +11,9 @@ use fbkl_entity::{
 };
 use tracing::instrument;
 
-use super::rdi_team_update::create_rdi_move_team_update;
+use crate::eligibility::{PlayerEligibilityFacts, validate_rdi_eligible};
+
+use super::{rdi_team_update::create_rdi_move_team_update, validate_contract_kind};
 
 #[instrument]
 pub async fn move_rookie_development_contract_to_international<C>(
@@ -21,6 +24,13 @@ pub async fn move_rookie_development_contract_to_international<C>(
 where
     C: ConnectionTrait + Debug,
 {
+    validate_contract_kind(&contract_model, ContractKind::RookieDevelopment)?;
+    let player_facts = match contract_model.get_player(db).await? {
+        RelatedPlayer::Player(model) => PlayerEligibilityFacts::from(&model),
+        RelatedPlayer::LeaguePlayer(model) => PlayerEligibilityFacts::from(&model),
+    };
+    validate_rdi_eligible(&contract_model, player_facts, db).await?;
+
     let team_model = contract_model.get_team(db).await?.ok_or_else(|| {
         eyre!(
             "Could not retrieve the expected team for an RD contract with id: {}",

--- a/logic/src/rookie_development_international/move_rdi_contract_from_international.rs
+++ b/logic/src/rookie_development_international/move_rdi_contract_from_international.rs
@@ -2,7 +2,8 @@ use std::fmt::Debug;
 
 use color_eyre::eyre::{Result, eyre};
 use fbkl_entity::{
-    contract, contract_queries, deadline,
+    contract::{self, ContractKind},
+    contract_queries, deadline,
     sea_orm::{ActiveValue, ConnectionTrait},
     team_update::ContractUpdateType,
     transaction::{self, TransactionKind},
@@ -10,7 +11,7 @@ use fbkl_entity::{
 };
 use tracing::instrument;
 
-use super::rdi_team_update::create_rdi_move_team_update;
+use super::{rdi_team_update::create_rdi_move_team_update, validate_contract_kind};
 
 #[instrument]
 pub async fn move_rookie_development_international_contract_to_stateside<C>(
@@ -21,6 +22,12 @@ pub async fn move_rookie_development_international_contract_to_stateside<C>(
 where
     C: ConnectionTrait + Debug,
 {
+    // §11.3.1 forced transition: leaving international is always legal, so kind is the only gate.
+    validate_contract_kind(
+        &contract_model,
+        ContractKind::RookieDevelopmentInternational,
+    )?;
+
     let team_model = contract_model.get_team(db).await?.ok_or_else(|| {
         eyre!(
             "Could not retrieve the expected team for an RD contract with id: {}",

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -23,6 +23,7 @@ mod m20221117_235325_create_transaction;
 mod m20230217_011454_create_team_update;
 mod m20260609_000001_create_job_run;
 mod m20260722_000001_collapse_transaction_fk_columns;
+mod m20260725_000001_add_player_eligibility_fields;
 
 pub struct Migrator;
 
@@ -46,6 +47,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230217_011454_create_team_update::Migration),
             Box::new(m20260609_000001_create_job_run::Migration),
             Box::new(m20260722_000001_collapse_transaction_fk_columns::Migration),
+            Box::new(m20260725_000001_add_player_eligibility_fields::Migration),
         ]
     }
 }

--- a/migration/src/m20260725_000001_add_player_eligibility_fields.rs
+++ b/migration/src/m20260725_000001_add_player_eligibility_fields.rs
@@ -1,8 +1,18 @@
 //! Adds the eligibility model of spec 10 to `player` + `league_player`.
 //!
-//! `has_been_on_nba_roster` is the rules §3.1.2 pivot that splits the veteran auction pool from
-//! the rookie draft pool. The classification itself is NOT stored — it is derived in
-//! `logic::eligibility` — so only the commissioner override (plus its audit trail) is persisted.
+//! Two distinct NBA facts, because the rules use them for different questions: whether the player
+//! has appeared in a game is the §3.1.2 pivot splitting the veteran auction pool from the rookie
+//! draft pool, while the broader "has been on an NBA roster" (§3.1.3) only gates RDI eligibility
+//! (§11.3). A rostered-but-never-played player is rookie-draft-eligible yet RDI-ineligible.
+//!
+//! Both facts are stored **as of a season**, not as career booleans, because eligibility is a
+//! point-in-time question: the same player is rookie-draft-eligible in the season before his debut
+//! and a veteran after it, and historical replay asks about past seasons.
+//! `nba_first_season_end_of_season_year` is the season the player first appeared in NBA data, so
+//! `<= the season in question` answers §3.1.3, and `has_played_nba_game` narrows that to §3.1.2.
+//!
+//! The classification itself is NOT stored — it is derived in `logic::eligibility` — so only the
+//! commissioner override (plus its audit trail) is persisted.
 
 use sea_orm_migration::{
     prelude::*,
@@ -30,7 +40,8 @@ impl MigrationTrait for Migration {
                 manager,
                 &format!(
                     "ALTER TABLE {table}
-                        ADD COLUMN has_been_on_nba_roster BOOLEAN NOT NULL DEFAULT FALSE,
+                        ADD COLUMN has_played_nba_game BOOLEAN NOT NULL DEFAULT FALSE,
+                        ADD COLUMN nba_first_season_end_of_season_year SMALLINT,
                         ADD COLUMN nba_roster_source VARCHAR NOT NULL DEFAULT 'Unknown',
                         ADD COLUMN nba_roster_asof TIMESTAMPTZ,
                         ADD COLUMN eligibility_override VARCHAR,
@@ -49,10 +60,11 @@ impl MigrationTrait for Migration {
                 ),
             )
             .await?;
+            // Pool assembly range-scans this to drop players with no NBA data as of the season.
             run_sql(
                 manager,
                 &format!(
-                    "CREATE INDEX {table}_has_been_on_nba_roster ON {table} (has_been_on_nba_roster)"
+                    "CREATE INDEX {table}_nba_first_season ON {table} (nba_first_season_end_of_season_year)"
                 ),
             )
             .await?;
@@ -67,7 +79,8 @@ impl MigrationTrait for Migration {
                 manager,
                 &format!(
                     "ALTER TABLE {table}
-                        DROP COLUMN has_been_on_nba_roster,
+                        DROP COLUMN has_played_nba_game,
+                        DROP COLUMN nba_first_season_end_of_season_year,
                         DROP COLUMN nba_roster_source,
                         DROP COLUMN nba_roster_asof,
                         DROP COLUMN eligibility_override,

--- a/migration/src/m20260725_000001_add_player_eligibility_fields.rs
+++ b/migration/src/m20260725_000001_add_player_eligibility_fields.rs
@@ -1,0 +1,84 @@
+//! Adds the eligibility model of spec 10 to `player` + `league_player`.
+//!
+//! `has_been_on_nba_roster` is the rules §3.1.2 pivot that splits the veteran auction pool from
+//! the rookie draft pool. The classification itself is NOT stored — it is derived in
+//! `logic::eligibility` — so only the commissioner override (plus its audit trail) is persisted.
+
+use sea_orm_migration::{
+    prelude::*,
+    sea_orm::{DatabaseBackend, Statement},
+};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+const TABLES: [&str; 2] = ["player", "league_player"];
+
+async fn run_sql(manager: &SchemaManager<'_>, sql: &str) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute(Statement::from_string(DatabaseBackend::Postgres, sql))
+        .await
+        .map(|_| ())
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        for table in TABLES {
+            run_sql(
+                manager,
+                &format!(
+                    "ALTER TABLE {table}
+                        ADD COLUMN has_been_on_nba_roster BOOLEAN NOT NULL DEFAULT FALSE,
+                        ADD COLUMN nba_roster_source VARCHAR NOT NULL DEFAULT 'Unknown',
+                        ADD COLUMN nba_roster_asof TIMESTAMPTZ,
+                        ADD COLUMN eligibility_override VARCHAR,
+                        ADD COLUMN eligibility_override_reason TEXT,
+                        ADD COLUMN eligibility_override_by_team_user_id BIGINT,
+                        ADD COLUMN eligibility_override_at TIMESTAMPTZ"
+                ),
+            )
+            .await?;
+            run_sql(
+                manager,
+                &format!(
+                    "ALTER TABLE {table} ADD CONSTRAINT {table}_fk_eligibility_override_by_team_user
+                        FOREIGN KEY (eligibility_override_by_team_user_id) REFERENCES team_user(id)
+                        ON UPDATE CASCADE ON DELETE SET NULL"
+                ),
+            )
+            .await?;
+            run_sql(
+                manager,
+                &format!(
+                    "CREATE INDEX {table}_has_been_on_nba_roster ON {table} (has_been_on_nba_roster)"
+                ),
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        for table in TABLES {
+            run_sql(
+                manager,
+                &format!(
+                    "ALTER TABLE {table}
+                        DROP COLUMN has_been_on_nba_roster,
+                        DROP COLUMN nba_roster_source,
+                        DROP COLUMN nba_roster_asof,
+                        DROP COLUMN eligibility_override,
+                        DROP COLUMN eligibility_override_reason,
+                        DROP COLUMN eligibility_override_by_team_user_id,
+                        DROP COLUMN eligibility_override_at"
+                ),
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+}

--- a/notes/2025-08-31-rules_document.md
+++ b/notes/2025-08-31-rules_document.md
@@ -81,9 +81,10 @@ Rules Document
 
 1. Definitions  
    1. “Contract” refers to the number of years the player has been a kept by a team.  There are no actual contracts in this league, in the sense of having a fixed salary commitment to a player over multiple years.  This league essentially has one-year contracts for all players with an option that increases the player salary to keep him next year, with restrictions on how many years a player may be kept.  
-   2. “Having been on an active NBA roster” is defined by an NBA entry for the player in basketball-reference.com.  A player does not necessarily have to have NBA game minutes logged, he may have just been on an NBA roster but not played in a game.  Any further questions over whether a player is classified as having previously been on an active NBA roster (for auction/draft purposes) will be decided by the commissioner.  
-   3. “League website” refers to the league hosting website (Fantrax), and not the league’s Google Group.  
-   4. “Original owner” for the purposes of who owns a player’s RFA/UFA exception, is the owner of the player at the time of the keeper deadline, when keepers are declared and RFAs/UFAs announced.  See 15\. Restricted Free Agents (RFA) and 16\. Unrestricted Free Agents (UFA).
+   2. “Having played in an NBA game” is defined by the player having appeared in at least one in-season (regular season or playoff) NBA game, per basketball-reference.com.  Being on an NBA roster without appearing in a game does not count, and neither do summer league, preseason, or G League games.  This is the pivot that splits the Veteran Auction pool from the Rookie Draft pool.  Any further questions over whether a player is classified as having played in an NBA game (for auction/draft purposes) will be decided by the commissioner.  
+   3. “Having been on an active NBA roster” is defined by an NBA entry for the player in basketball-reference.com — he may have been rostered without appearing in a game.  This is a separate, broader fact than 3.1.2 above, and is only used for RDI eligibility (see 11\. Rookie-Development Squad, 11.3); it does not affect Veteran Auction or Rookie Draft eligibility.  
+   4. “League website” refers to the league hosting website (Fantrax), and not the league’s Google Group.  
+   5. “Original owner” for the purposes of who owns a player’s RFA/UFA exception, is the owner of the player at the time of the keeper deadline, when keepers are declared and RFAs/UFAs announced.  See 15\. Restricted Free Agents (RFA) and 16\. Unrestricted Free Agents (UFA).
 
 **II. LEAGUE CONFIGURATION**
 
@@ -118,7 +119,7 @@ Rules Document
    1. The Veteran Auction is held every year and is the only way to acquire free agent veterans before the season begins.  
    2. Any players not bid on in the Veteran Auction will be free agents available for bidding during the season.  
 2. Player Pool  
-   1. All NBA veterans (players who have been on an active NBA roster at any point in their career) are eligible to be bid on in the Veteran Auction.  
+   1. All NBA veterans (players who have played in an NBA game at any point in their career) are eligible to be bid on in the Veteran Auction.  
    2. The Veteran Auction pool is made up of Free Agents, Unrestricted Free Agents, and Restricted Free Agents.  
       1. Free Agents (FA) were either not previously owned, or the original owner did not keep the player, or the player was an RFA that was not bid on and not re-signed.  
       2. Unrestricted Free Agents (UFA) were previously owned either up to the 3 year maximum contract (if signed via Veteran Auction), or the 5 year maximum contract (if signed via Rookie Draft).  The original owner is allowed to participate in an auction for a UFA.  UFAs have veteran exceptions, which are re-signing discounts for the original owner (see 16\. Unrestricted Free Agents (UFA) below for more details).  
@@ -172,16 +173,16 @@ Rules Document
    1. The below players are eligible to be drafted in the Rookie Draft:  
       1. Rookies drafted in the NBA Draft for that year  
       2. Players that declared for the NBA Draft and went undrafted  
-      3. Players playing in summer league that have never been on an active NBA roster  
-      4. Players playing in the NBA G League that have never been on an active NBA roster  
-      5. Foreign players that have been previously drafted by an NBA team that have never been on an active NBA roster  
-      6. Former American college players (drafted or undrafted) playing overseas that have never been on an active NBA roster.  
+      3. Players playing in summer league that have never played in an NBA game  
+      4. Players playing in the NBA G League that have never played in an NBA game  
+      5. Foreign players that have been previously drafted by an NBA team that have never played in an NBA game  
+      6. Former American college players (drafted or undrafted) playing overseas that have never played in an NBA game.  
    2. The below players are ineligible to be drafted in the Rookie Draft:  
-      1. Any player that has been on an active NBA roster at any point in his career  
+      1. Any player that has played in an NBA game at any point in his career  
       2. College players not covered in the above list of eligible players  
       3. High school or other players not covered in the above list of eligible players  
       4. Foreign players not covered in the above list of eligible players  
-   3. Previous league draft/ownership status does not affect whether a player is Rookie Draft eligible \- if a player was previously drafted in the Rookie Draft, that player can still potentially be drafted again in later years if he is not on a roster (assuming he is still eligible, i.e. has never been on an active NBA roster).
+   3. Previous league draft/ownership status does not affect whether a player is Rookie Draft eligible \- if a player was previously drafted in the Rookie Draft, that player can still potentially be drafted again in later years if he is not on a roster (assuming he is still eligible, i.e. has never played in an NBA game).
 
 **IV. IN-SEASON**
 
@@ -207,7 +208,7 @@ Rules Document
       1. Example: Joe wins Davion Mitchell for $7 and Jose Alvarado for $1 in Week 2\.  He must add both Davion Mitchell and Jose Alvarado for that week; he may not add Jose Alvarado, then drop him to make space and add Davion Mitchell after that.  However, he is free to drop either Mitchell or Alvarado after they are both legally added to his roster.  
    8. Once a player(s) is won in auction, owners must send out an FA report email to the Google Group, specifying his pickups and drops for the week, and his new salary cap figures after pickups/drops.  
 4. Eligibility  
-   1. Any players (including rookies) that were eligible in the Veteran Auction or the Rookie Draft, are eligible for bidding.  This includes: any NBA veterans (has been on an active NBA roster at any point in his career), NBA rookies (drafted or undrafted), NBA G League players, previously drafted foreign players, and former American collegiates playing overseas.  
+   1. Any players (including rookies) that were eligible in the Veteran Auction or the Rookie Draft, are eligible for bidding.  This includes: any NBA veterans (has played in an NBA game at any point in his career), NBA rookies (drafted or undrafted), NBA G League players, previously drafted foreign players, and former American collegiates playing overseas.  
    2. All players that were ineligible for the Veteran Auction and Rookie Draft are still ineligible for In-Season Free Agency.  This includes: current college or high school players, and foreign players that were not previously drafted and not former American collegiates.  
 5. Examples  
    1. Bidding example (all times are CT):  
@@ -232,7 +233,7 @@ Rules Document
    4. Nick Adenhart rule: if a player dies in-season, or at any time between the declaration of keepers and the start of the season, the owner of that player may drop him immediately without any salary cap penalty.  
    5. RD/RDI players may be dropped without penalty.  
 2. Dropped Players  
-   1. Dropped players (including RD/RDI players) retain the salary they had before they were dropped, as a minimum starting bid for in-season free agent auctions.  After the season is over, all dropped players return to the Veteran Auction pool (if they are NBA veterans, players never on an active NBA roster would be Rookie Draft eligible) and no longer have a minimum starting bid.  Salaries for dropped players in-season will be tracked via a google spreadsheet.  
+   1. Dropped players (including RD/RDI players) retain the salary they had before they were dropped, as a minimum starting bid for in-season free agent auctions.  After the season is over, all dropped players return to the Veteran Auction pool (if they are NBA veterans, players who have never played in an NBA game would be Rookie Draft eligible) and no longer have a minimum starting bid.  Salaries for dropped players in-season will be tracked via a google spreadsheet.  
    2. Dropped players are released into the free agent pool the week after they are dropped, and may be bid on by any owner with a starting minimum bid of the player’s salary before he was dropped.
 
 **10\. Injured Reserve**
@@ -360,7 +361,7 @@ Rules Document
    2. A player signed through the Veteran Auction or In-Season Free Agency has a maximum 3 year contract (maximum 3 years in a contract, including trades, before he is not allowed to be kept).  After the 3rd year in the contract, the player is released into the Veteran Auction pool as a unrestricted free agent (UFA).  The original owner is allowed to bid on a UFA.  As a UFA, he will be slotted into the Veteran Auction as if he were a normal free agent; however, the original owner gets a veteran exception as detailed under 16\. Unrestricted Free Agents (UFA).  
    3. A player signed via in-season free agency is considered to be in year 1 of his contract.  Thus, if a player is signed towards the end of a season before the in-season free agency freeze, then kept into next season, he is now in year 2 of his contract.  
 4. Deadline  
-   1. Keepers will be declared by a specified deadline, shortly before the start of the Veteran Auction.  Each owner decides which of his keeper-eligible players he will be keeping with the salary increase, with all non-kept players released into the Veteran Auction (for NBA veterans) or Rookie Draft (for players that have never been on an active NBA roster).  
+   1. Keepers will be declared by a specified deadline, shortly before the start of the Veteran Auction.  Each owner decides which of his keeper-eligible players he will be keeping with the salary increase, with all non-kept players released into the Veteran Auction (for NBA veterans) or Rookie Draft (for players that have never played in an NBA game).  
    2. The keeper deadline is also when RFAs and UFAs are announced.  The owners of any players that are ineligible to be kept (3rd and 5th year players) will have their RFA/UFA exceptions for the next Veteran Auction.  See 15\. Restricted Free Agents (RFA) and 16\. Unrestricted Free Agents (UFA).
 
 **15\. Restricted Free Agents (RFA)**

--- a/notes/implementation-specs/10-eligibility-and-player-pool.md
+++ b/notes/implementation-specs/10-eligibility-and-player-pool.md
@@ -4,25 +4,44 @@
 ## Summary
 
 The whole league splits players into two acquisition pools by one fact: **has the player ever
-been on an active NBA roster?** (§3.1.2 — defined by an NBA entry on basketball-reference.com;
-game minutes not required). That single pivot decides:
+appeared in an in-season NBA game?** (§3.1.2 — a regular season or playoff appearance per
+basketball-reference.com; roster presence alone, summer league, preseason, and G League do not
+count). That single pivot decides:
 
-- **Veteran Auction pool** (§6.2.1): all players who *have* been on an active NBA roster.
-- **Rookie Draft pool** (§7.5): a constrained set of players who have *never* been on an active
-  NBA roster.
+- **Veteran Auction pool** (§6.2.1): all players who *have* played in an NBA game.
+- **Rookie Draft pool** (§7.5): a constrained set of players who have *never* played in an NBA game.
 - **In-season FA pool** (§8.4): the union of the two above; everyone ineligible for both auction
   and draft stays ineligible for FA.
 
-This pivot is **not modeled today.** `player`/`league_player` carry only `is_rdi_eligible: bool`
-and (on `player`) `PlayerStatus { Active, Retired }` — neither encodes NBA-roster history nor a
+A **second, broader** fact — has the player ever been on an active NBA roster (§3.1.3, the NBA
+entry on basketball-reference.com regardless of appearances) — is deliberately *not* the pool
+pivot. It is used only for RDI eligibility, because §11.3.1 forces RDI→RD/1 as soon as a player is
+"on an NBA roster / signed to an NBA contract". A rostered player who never appeared in a game is
+therefore still rookie-draft-eligible but already RDI-ineligible, so both facts must be stored.
+
+Both are **point-in-time, not career booleans.** Eligibility is a question about a season: the same
+player is rookie-draft-eligible the season before his debut and a veteran after it, the pool
+builders already take an `end_of_season_year`, and historical replay asks about past seasons. So the
+stored facts are a first-NBA-season stamp plus a career "ever appeared" bool, and every caller says
+which season it means — pool builders their pool's, contract guards the contract's.
+
+The season comparison is **strictly earlier**, not same-or-earlier. The stamp is season-granular
+while the rules turn on *where in* a season the player arrived: §11.3.5 gives an RDI who lands on an
+NBA roster mid-season until the *next* legalization to move, and both a mid-season signing and a
+draft-and-stash record the season they arrived in. Same-or-earlier would reject exactly the
+legalization §11.3.5 protects — it rejects 2 of the 25 historical RD→RDI moves (Tristan Vukcevic,
+who signed with Washington in March 2024, and Saliou Niang, stashed under his draft season).
+
+Neither fact is **modeled today.** `player`/`league_player` carry only `is_rdi_eligible: bool`
+and (on `player`) `PlayerStatus { Active, Retired }` — neither encodes NBA history nor a
 draft-vs-auction classification. Spec covers: (1) an eligibility model on the player entities,
-(2) where the NBA-roster fact is ingested from (cross-ref [spec 12](12-out-of-scope-and-external.md)),
+(2) where the NBA facts are ingested from (cross-ref [spec 12](12-out-of-scope-and-external.md)),
 (3) pool-assembly functions in `logic/`, (4) the **missing eligibility guards** on
 `rookie_development_activation` + `rookie_development_international` (a known gap — they skip the
 pre-mutation `ensure!`/`bail!` that `ir`/`drop` enforce), (5) an RDI eligibility validator, and
 (6) a commissioner override for the §3.1.2 / §11.3.6 "decided by the commissioner" edge cases.
 
-NBA-roster status and NBA-IR status are derived/ingested data — see
+NBA game/roster status and NBA-IR status are derived/ingested data — see
 [spec 12](12-out-of-scope-and-external.md) for the source and freshness contract.
 
 ## Backend
@@ -33,13 +52,23 @@ Add to **`player`** (the real-world NBA player; `entity/src/entities/player.rs`)
 **`league_player`** (`entity/src/entities/league_player.rs`, used for drafted-but-not-yet-NBA
 custom players) the following fields, via a new migration:
 
-- `has_been_on_nba_roster: bool` — the §3.1.2 pivot. Source of truth for the auction-vs-draft
-  split. On `league_player`, `false` is the normal case (a custom player exists *because* he has
-  no NBA entry yet); flipping to `true` is the §11.3.1 trigger to move RDI→RD/1.
+- `has_played_nba_game: bool` — whether the player ever appeared in an in-season NBA game, over his
+  whole career. On `league_player`, `false` is the normal case (a custom player exists *because* he
+  has no NBA entry yet).
+- `nba_first_season_end_of_season_year: Option<i16>` — the season the player first appeared in NBA
+  data, `None` for never. Setting it is the §11.3.1 trigger to move RDI→RD/1. Required whenever
+  `has_played_nba_game` is true (you cannot appear in a game with no season to appear in), so that
+  pair is rejected at the write boundary.
 - `nba_roster_source: NbaRosterSource` enum `{ BasketballReference, Espn, Nba, CommissionerOverride, Unknown }`
-  — provenance of the flag.
-- `nba_roster_asof: Option<DateTimeWithTimeZone>` — when the flag was last evaluated (freshness;
-  the flag is only as good as the last ingest — see edge cases).
+  — provenance of both facts, which one ingest sets together.
+- `nba_roster_asof: Option<DateTimeWithTimeZone>` — when the facts were last evaluated (freshness;
+  they are only as good as the last ingest — see edge cases). `None` means never ingested, which is
+  how a dump-loaded database is distinguishable from one an importer has filled in.
+
+The two are combined into as-of-a-season predicates in `logic`, never read raw by rule code:
+
+- `was_on_nba_roster_before(season)` — §3.1.3: `nba_first_season < season`.
+- `had_played_nba_game_before(season)` — §3.1.2: the above, narrowed by `has_played_nba_game`.
 - `eligibility_override: Option<EligibilityClassification>` — commissioner manual override
   (§3.1.2, §11.3.6). When `Some`, it wins over the derived classification.
 - `eligibility_override_reason: Option<String>` + `eligibility_override_by_team_user_id` /
@@ -49,8 +78,8 @@ New enum (entity, `async_graphql::Enum` + `DeriveActiveEnum`, same pattern as `P
 
 ```rust
 pub enum EligibilityClassification {
-    RookieDraftEligible,    // never on NBA roster AND in the §7.5.1 eligible set
-    VeteranAuctionEligible, // has been on an active NBA roster (§6.2.1)
+    RookieDraftEligible,    // never played an NBA game AND in the §7.5.1 eligible set
+    VeteranAuctionEligible, // has played in an NBA game (§6.2.1)
     Ineligible,             // §7.5.2 / §8.4.2 — current college/HS, undrafted foreign non-collegian, etc.
 }
 ```
@@ -58,7 +87,7 @@ pub enum EligibilityClassification {
 Classification is **derived**, not stored as a column, by a pure fn (see pool assembly). The
 stored `eligibility_override` short-circuits it. Reasoning for keeping it derived: `RookieDraft`
 vs `Veteran` membership shifts over time (a draft-eligible player who signs an NBA contract
-mid-cycle flips to veteran — §11.3.1) and must always reflect current `has_been_on_nba_roster`.
+mid-cycle flips to veteran once he debuts) and must always reflect current `has_played_nba_game`.
 
 `PlayerStatus { Active, Retired }` stays as-is — it answers "show in search?", a different
 question than "which pool?". Do not overload it.
@@ -69,11 +98,18 @@ question than "which pool?". Do not overload it.
 `player.to_year == 2024` only — it derives nothing about NBA-roster history. Extend the importer
 (NBA player index `data/nba_player_index_*.json`; cross-ref [spec 12](12-out-of-scope-and-external.md)):
 
-- A player present in the NBA player index with any season played ⇒ `has_been_on_nba_roster = true`,
-  `nba_roster_source = Nba` (or `BasketballReference` once that source is wired), `nba_roster_asof = now()`.
-- A `league_player` (drafted, no NBA entry) ⇒ `has_been_on_nba_roster = false`, source `Unknown`
-  until an ingest confirms, asof set on each run.
-- **Manual / commissioner path:** a mutation to set `has_been_on_nba_roster` +
+- A player present in the NBA player index ⇒ `nba_first_season_end_of_season_year = FROM_YEAR + 1`
+  (index presence *is* the §3.1.3 NBA entry, and `FROM_YEAR` is a season *start* year so its
+  end-of-season year is one later), `nba_roster_source = Nba` (or `BasketballReference` once that
+  source is wired), `nba_roster_asof = now()`.
+- `has_played_nba_game` comes from the index's career `PTS` column: it is null only for players with
+  no in-season appearance (86 of 5087 rows in `nba_player_index_2025-07-01.json` — e.g. Terrico
+  White, Da'Sean Butler, Magnum Rolle, plus current-year draftees who have not debuted). `PTS = 0.0`
+  means he played and scored none, so null-vs-zero is the whole signal. The index carries no `GP`
+  column; if spec 12 wires a source that does, prefer `GP > 0`.
+- A `league_player` (drafted, no NBA entry) ⇒ `has_played_nba_game = false` and a `None` first
+  season, source `Unknown` until an ingest confirms, asof set on each run.
+- **Manual / commissioner path:** a mutation to set both facts +
   `nba_roster_source = CommissionerOverride` for the §3.1.2 "any further questions … decided by
   the commissioner" cases and for players the automated feed lags on (summer-league signings,
   10-day contracts). This is distinct from `eligibility_override` (which overrides the *derived
@@ -90,17 +126,19 @@ New module `logic/src/eligibility/` exposing pure classifiers + pool builders. T
 underlying filtered queries to `entity/src/queries/player_queries.rs` /
 `league_player_queries.rs` (currently only `find_player_by_id` / `find_players_by_name`).
 
-- `classify_player(player_facts) -> EligibilityClassification` — pure. Order:
+- `classify_player(player_facts, end_of_season_year) -> EligibilityClassification` — pure. Order:
   1. If `eligibility_override.is_some()` ⇒ return it.
-  2. If `has_been_on_nba_roster` ⇒ `VeteranAuctionEligible` (§6.2.1).
+  2. If `had_played_nba_game_before(end_of_season_year)` ⇒ `VeteranAuctionEligible` (§6.2.1). The
+     §3.1.3 roster fact is *not* consulted here — a rostered player who never appeared stays in the
+     draft pool.
   3. Else if in the §7.5.1 rookie-eligible set (drafted-this-year, declared-undrafted,
-     summer-league-never-NBA, G-League-never-NBA, previously-drafted-foreign-never-NBA,
-     former-American-collegian-overseas-never-NBA) ⇒ `RookieDraftEligible`.
+     summer-league-never-played, G-League-never-played, previously-drafted-foreign-never-played,
+     former-American-collegian-overseas-never-played) ⇒ `RookieDraftEligible`.
   4. Else (§7.5.2: current college/HS, undrafted foreign non-collegian, other) ⇒ `Ineligible`.
   - Note: the §7.5.1 sub-categories are not yet representable from current data (we only have
     "in NBA index" vs "custom league_player"). Until [spec 12](12-out-of-scope-and-external.md)
     or [spec 02](02-rookie-draft-engine.md) lands richer source tags, approximate
-    `RookieDraftEligible = !has_been_on_nba_roster && (is a drafted league_player || flagged
+    `RookieDraftEligible = !has_played_nba_game && (is a drafted league_player || flagged
     draft-eligible)` and rely on `eligibility_override` for edge cases. Capture the data gap as
     an open question below.
 - `build_veteran_auction_pool(league_id, end_of_season_year, db)` — players classified
@@ -109,7 +147,7 @@ underlying filtered queries to `entity/src/queries/player_queries.rs` /
   auction pool + the keeper-deadline results in `deadline_processing/keeper_deadline`).
 - `build_rookie_draft_eligible_pool(league_id, end_of_season_year, db)` — players classified
   `RookieDraftEligible`. **§7.5.3:** prior league draft/ownership does **not** affect eligibility —
-  a previously-drafted-but-now-unrostered, never-NBA player is still eligible. So the filter keys
+  a previously-drafted-but-now-unrostered player who never played is still eligible. So the filter keys
   off classification + current-roster status only, never historical `contract` rows. (Caveat the
   §7.3.4 same-draft re-draft rule — that's a draft-engine concern, [spec 02](02-rookie-draft-engine.md).)
 - `build_in_season_fa_pool(league_id, end_of_season_year, db)` — `VeteranAuctionEligible` ∪
@@ -146,8 +184,10 @@ in line:
 - Player is RD-eligible (was drafted in the Rookie Draft) — i.e. `EligibilityClassification`
   resolves to `RookieDraftEligible`.
 - Player is **currently playing overseas** AND has **never been on an NBA roster / signed an NBA
-  contract** ⇒ `ensure!(!has_been_on_nba_roster, …)`. (Source of "playing overseas" + NBA-contract
-  signal is ingested data — [spec 12](12-out-of-scope-and-external.md).)
+  contract** ⇒ `ensure!(!facts.was_on_nba_roster_before(contract.end_of_season_year), …)`. This is
+  the §3.1.3 fact, deliberately broader than the §3.1.2 pool pivot, so the check does not collapse
+  into the `RookieDraftEligible` test above. (Source of "playing overseas" + NBA-contract signal is
+  ingested data — [spec 12](12-out-of-scope-and-external.md).)
 - **Not formerly RD** (§11.3.1 last sentence): a player who was ever a *post-legalization* RD
   contract cannot become RDI. Drafted players are RD/1 initially; the disqualifier is having been
   RD at/after an in-season roster legalization. Determine this from the contract chain
@@ -161,11 +201,12 @@ in line:
 The player/contract GraphQL surface is commented out today (`server/src/graphql/player`,
 `contract`). When [spec 06](06-graphql-api-surface.md) wires it:
 
-- Expose `EligibilityClassification`, `has_been_on_nba_roster`, `nba_roster_source/asof` on the
-  player types.
+- Expose `EligibilityClassification`, `has_played_nba_game`,
+  `nba_first_season_end_of_season_year`, `nba_roster_source/asof` on the player types, plus the
+  season the classification was derived for so a cached client can't mistake it for timeless.
 - Query: eligible-player lists per context — `veteranAuctionPool`, `rookieDraftEligiblePool`,
   `inSeasonFreeAgentPool` — backed by the logic builders above.
-- Mutations (commissioner-only, auth-gated): `setPlayerNbaRosterStatus` (fact correction) and
+- Mutations (commissioner-only, auth-gated): `setPlayerNbaStatus` (both fact corrections) and
   `overridePlayerEligibility` (classification override, with reason → audit fields). Keep these
   two distinct per the ingestion section.
 
@@ -177,24 +218,30 @@ The player/contract GraphQL surface is commented out today (`server/src/graphql/
   hitting the matching pool query. Columns: name, NBA team / overseas, classification chip
   (Veteran / Rookie-Draft / Ineligible), `nba_roster_asof` freshness, override badge if set.
 - **Commissioner eligibility override UI:** an admin-only panel to (a) toggle
-  `has_been_on_nba_roster` (fact correction, with source) and (b) set/clear
+  `has_played_nba_game` / `nba_first_season_end_of_season_year` (fact correction, with source) and (b) set/clear
   `eligibility_override` with a required reason. Show current derived classification vs the
   override so the commissioner sees what they're changing. Surface the audit trail
   (who/when/why). Use MUI v7 tree-shaking imports per project ESLint rule.
 
 ## Edge cases & open questions
 
-- **Mid-season NBA signing flips eligibility.** An RDI / rookie-draft-eligible player who signs an
-  NBA contract mid-season becomes `VeteranAuctionEligible` and (§11.3.1) must move RDI→RD/1 at the
-  next in-season roster legalization (not immediately — §11.3.5). Pool membership for *next*
-  auction/draft must reflect the flip; the RDI→RD forced move is handled by the guard above but is
-  *deferred to legalization*, so classification and roster-move timing differ. Resolve exact
-  trigger timing with [spec 05](05-deadline-scheduler-and-transaction-processor.md) /
+- **Mid-season NBA signing and debut are different facts, and the stamp is only season-granular.**
+  Being rostered sets the first-NBA-season stamp, which (§11.3.1) forces RDI→RD/1 at the next
+  in-season roster legalization, not immediately (§11.3.5) — hence the strictly-earlier comparison.
+  Only the *debut* sets `has_played_nba_game`, which moves him to `VeteranAuctionEligible`. The two
+  can be a season apart: a stashed player signed in January who never appears is RDI-ineligible from
+  the following season on and still rookie-draft-eligible. Within a season the stamp cannot tell a
+  July signing from a March one, so a player signed *before* the season starts is treated as having
+  the §11.3.5 grace period he isn't strictly owed — deliberately permissive, since the guard should
+  not reject history that was legal. Resolve exact trigger timing with
+  [spec 05](05-deadline-scheduler-and-transaction-processor.md) /
   [spec 11](11-roster-legalization-and-in-season.md).
 - **basketball-reference data source & freshness.** §3.1.2 names basketball-reference as the
-  authority, but the importer reads the NBA player index. Either reconcile sources or treat
-  `nba_roster_source` as informational and let commissioner override settle conflicts. Staleness
-  window (`nba_roster_asof`) needs a documented SLA — owned by [spec 12](12-out-of-scope-and-external.md).
+  authority, but the importer reads the NBA player index and infers "played" from a non-null career
+  `PTS`. Either reconcile sources or treat `nba_roster_source` as informational and let commissioner
+  override settle conflicts. A source exposing `GP` would be strictly better than the PTS proxy.
+  Staleness window (`nba_roster_asof`) needs a documented SLA — owned by
+  [spec 12](12-out-of-scope-and-external.md).
 - **Override audit trail.** Are overrides reversible without losing history? Recommend append-only
   (keep prior override + reason) rather than overwrite. Open.
 - **§7.5.3 re-draft eligibility.** Confirm `build_rookie_draft_eligible_pool` ignores all prior

--- a/server/src/graphql.rs
+++ b/server/src/graphql.rs
@@ -8,6 +8,7 @@ use self::{
     contract::ContractQuery,
     deadline::{DeadlineMutation, DeadlineQuery},
     draft::DraftQuery,
+    eligibility::{EligibilityMutation, EligibilityQuery},
     keeper::{KeeperMutation, KeeperQuery},
     league::{LeagueMutation, LeagueQuery},
     player::PlayerQuery,
@@ -18,19 +19,21 @@ use self::{
     user::UserQuery,
 };
 
-pub use self::{authz::*, error::*, loaders::*};
+pub use self::{authz::*, error::*, loaders::*, season::*};
 
 mod auction;
 mod authz;
 mod contract;
 mod deadline;
 mod draft;
+mod eligibility;
 mod error;
 mod keeper;
 mod league;
 mod loaders;
 mod player;
 mod roster;
+mod season;
 mod team;
 mod trade;
 mod transaction;
@@ -51,6 +54,7 @@ pub struct QueryRoot(
     DeadlineQuery,
     AuctionQuery,
     DraftQuery,
+    EligibilityQuery,
 );
 
 #[derive(Default, MergedObject)]
@@ -60,4 +64,5 @@ pub struct MutationRoot(
     RosterMutation,
     KeeperMutation,
     DeadlineMutation,
+    EligibilityMutation,
 );

--- a/server/src/graphql/auction/auction_resolvers.rs
+++ b/server/src/graphql/auction/auction_resolvers.rs
@@ -2,20 +2,17 @@
 //! open and settle through deadline processing, never as a direct mutation.
 
 use async_graphql::{Context, Object, Result, SimpleObject};
-use chrono::Utc;
 use fbkl_entity::{
     auction::{self, AuctionKind},
     auction_bid,
     auction_queries::{find_auction_bids, find_auction_by_id, find_open_auctions_in_league},
     deadline::DeadlineKind,
-    deadline_queries::{
-        find_most_recent_deadline_by_datetime, find_sorted_deadlines_for_league_season,
-    },
+    deadline_queries::find_sorted_deadlines_for_league_season,
     sea_orm::DatabaseConnection,
 };
 
 use crate::graphql::{
-    ErrorCode, LeagueRoleGuard, RoleRequirement, code_error, deadline::Deadline,
+    ErrorCode, LeagueRoleGuard, RoleRequirement, code_error, current_season, deadline::Deadline,
     require_league_role,
 };
 
@@ -192,16 +189,4 @@ async fn load_auction_in_league(ctx: &Context<'_>, auction_id: i64) -> Result<au
     }
 
     Ok(auction_model)
-}
-
-async fn current_season(ctx: &Context<'_>, league_id: i64) -> Result<i16> {
-    let db = ctx.data_unchecked::<DatabaseConnection>();
-    let deadline = find_most_recent_deadline_by_datetime(league_id, Utc::now().fixed_offset(), db)
-        .await
-        .map_err(|err| {
-            tracing::error!(error = ?err, league_id, "failed to resolve the current season");
-            code_error(ErrorCode::Internal)
-        })?;
-
-    Ok(deadline.end_of_season_year)
 }

--- a/server/src/graphql/contract/contract_types.rs
+++ b/server/src/graphql/contract/contract_types.rs
@@ -119,6 +119,7 @@ impl Contract {
                     .ok_or_else(|| eyre!("player {player_id} not found"))?;
                 Ok(LeagueOrRealPlayer::RealPlayer(RealPlayer::from_model(
                     player,
+                    self.end_of_season_year,
                 )))
             }
             PlayerRef::League(league_player_id) => {
@@ -130,6 +131,7 @@ impl Contract {
                     .ok_or_else(|| eyre!("league player {league_player_id} not found"))?;
                 Ok(LeagueOrRealPlayer::LeaguePlayer(LeaguePlayer::from_model(
                     league_player,
+                    self.end_of_season_year,
                 )))
             }
         }

--- a/server/src/graphql/eligibility.rs
+++ b/server/src/graphql/eligibility.rs
@@ -1,0 +1,3 @@
+mod eligibility_resolvers;
+
+pub use eligibility_resolvers::*;

--- a/server/src/graphql/eligibility/eligibility_resolvers.rs
+++ b/server/src/graphql/eligibility/eligibility_resolvers.rs
@@ -2,15 +2,15 @@
 //!
 //! Every classification rule lives in `fbkl_logic::eligibility`; these resolvers only fetch,
 //! authorize, and map to GraphQL types. The two mutations stay deliberately separate:
-//! `setPlayerNbaRosterStatus` corrects the underlying *fact*, `overridePlayerEligibility`
+//! `setPlayerNbaStatus` corrects the underlying *facts*, `overridePlayerEligibility`
 //! overrides the *derived classification*.
 
 use async_graphql::{Context, Object, Result, SimpleObject};
 use fbkl_entity::{
     contract::RelatedPlayer,
     eligibility_queries::{
-        set_league_player_eligibility_override, set_league_player_nba_roster_status,
-        set_player_eligibility_override, set_player_nba_roster_status,
+        set_league_player_eligibility_override, set_league_player_nba_status,
+        set_player_eligibility_override, set_player_nba_status,
     },
     league_player_queries::find_league_player_by_id,
     player::EligibilityClassification,
@@ -54,9 +54,9 @@ impl EligibilityQuery {
             .map_err(|err| internal("failed to build the veteran auction pool", &err))?;
 
         Ok(VeteranAuctionPool {
-            restricted: to_graphql(pool.restricted_free_agents),
-            unrestricted: to_graphql(pool.unrestricted_free_agents),
-            free_agents: to_graphql(pool.free_agents),
+            restricted: to_graphql(pool.restricted_free_agents, season),
+            unrestricted: to_graphql(pool.unrestricted_free_agents, season),
+            free_agents: to_graphql(pool.free_agents, season),
         })
     }
 
@@ -74,7 +74,7 @@ impl EligibilityQuery {
             .await
             .map_err(|err| internal("failed to build the rookie draft pool", &err))?;
 
-        Ok(to_graphql(pool))
+        Ok(to_graphql(pool, season))
     }
 
     /// Players signable in-season: both eligible pools minus current rosters (§8.4).
@@ -91,7 +91,7 @@ impl EligibilityQuery {
             .await
             .map_err(|err| internal("failed to build the in-season free agent pool", &err))?;
 
-        Ok(to_graphql(pool))
+        Ok(to_graphql(pool, season))
     }
 }
 
@@ -100,32 +100,55 @@ pub struct EligibilityMutation;
 
 #[Object]
 impl EligibilityMutation {
-    /// Commissioner correction of the NBA-roster *fact* the classification derives from.
+    /// Commissioner correction of the NBA *facts* the classification derives from.
+    /// `nbaFirstSeasonEndOfSeasonYear` is when the player first appeared in NBA data — `null` for
+    /// never — and `hasPlayedNbaGame` says whether any of that was an actual game appearance.
     #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Commissioner)")]
-    async fn set_player_nba_roster_status(
+    async fn set_player_nba_status(
         &self,
         ctx: &Context<'_>,
         kind: PlayerSearchKind,
         id: i64,
-        has_been_on_nba_roster: bool,
+        has_played_nba_game: bool,
+        nba_first_season_end_of_season_year: Option<i16>,
     ) -> Result<LeagueOrRealPlayer> {
+        // Appearing in a game requires an NBA season to have appeared in.
+        if has_played_nba_game && nba_first_season_end_of_season_year.is_none() {
+            return Err(graphql_error(
+                ErrorCode::BadRequest,
+                "a player who has played in an NBA game needs a first NBA season",
+            ));
+        }
+
         let db = ctx.data_unchecked::<DatabaseConnection>();
+        let (_, caller_team) = require_league_role(ctx, RoleRequirement::Commissioner).await?;
+        let season = current_season(ctx, caller_team.league_id).await?;
         let related_player = load_player_for_commissioner(ctx, kind, id).await?;
 
         let updated = match related_player {
             RelatedPlayer::LeaguePlayer(model) => RelatedPlayer::LeaguePlayer(
-                set_league_player_nba_roster_status(model, has_been_on_nba_roster, db)
-                    .await
-                    .map_err(|err| internal("failed to set the NBA roster status", &err))?,
+                set_league_player_nba_status(
+                    model,
+                    has_played_nba_game,
+                    nba_first_season_end_of_season_year,
+                    db,
+                )
+                .await
+                .map_err(|err| internal("failed to set the NBA status", &err))?,
             ),
             RelatedPlayer::Player(model) => RelatedPlayer::Player(
-                set_player_nba_roster_status(model, has_been_on_nba_roster, db)
-                    .await
-                    .map_err(|err| internal("failed to set the NBA roster status", &err))?,
+                set_player_nba_status(
+                    model,
+                    has_played_nba_game,
+                    nba_first_season_end_of_season_year,
+                    db,
+                )
+                .await
+                .map_err(|err| internal("failed to set the NBA status", &err))?,
             ),
         };
 
-        Ok(LeagueOrRealPlayer::from_related_player(updated))
+        Ok(LeagueOrRealPlayer::from_related_player(updated, season))
     }
 
     /// Commissioner override of the *derived* classification. `classification: null` clears it.
@@ -146,7 +169,9 @@ impl EligibilityMutation {
         }
 
         let db = ctx.data_unchecked::<DatabaseConnection>();
-        let (team_user, _) = require_league_role(ctx, RoleRequirement::Commissioner).await?;
+        let (team_user, caller_team) =
+            require_league_role(ctx, RoleRequirement::Commissioner).await?;
+        let season = current_season(ctx, caller_team.league_id).await?;
         let related_player = load_player_for_commissioner(ctx, kind, id).await?;
 
         let updated = match related_player {
@@ -168,7 +193,7 @@ impl EligibilityMutation {
             ),
         };
 
-        Ok(LeagueOrRealPlayer::from_related_player(updated))
+        Ok(LeagueOrRealPlayer::from_related_player(updated, season))
     }
 }
 
@@ -213,10 +238,10 @@ async fn league_and_season(
     Ok((caller_team.league_id, season))
 }
 
-fn to_graphql(members: Vec<RelatedPlayer>) -> Vec<LeagueOrRealPlayer> {
+fn to_graphql(members: Vec<RelatedPlayer>, end_of_season_year: i16) -> Vec<LeagueOrRealPlayer> {
     members
         .into_iter()
-        .map(LeagueOrRealPlayer::from_related_player)
+        .map(|member| LeagueOrRealPlayer::from_related_player(member, end_of_season_year))
         .collect()
 }
 

--- a/server/src/graphql/eligibility/eligibility_resolvers.rs
+++ b/server/src/graphql/eligibility/eligibility_resolvers.rs
@@ -1,0 +1,226 @@
+//! Eligibility reads + commissioner corrections (spec 10).
+//!
+//! Every classification rule lives in `fbkl_logic::eligibility`; these resolvers only fetch,
+//! authorize, and map to GraphQL types. The two mutations stay deliberately separate:
+//! `setPlayerNbaRosterStatus` corrects the underlying *fact*, `overridePlayerEligibility`
+//! overrides the *derived classification*.
+
+use async_graphql::{Context, Object, Result, SimpleObject};
+use fbkl_entity::{
+    contract::RelatedPlayer,
+    eligibility_queries::{
+        set_league_player_eligibility_override, set_league_player_nba_roster_status,
+        set_player_eligibility_override, set_player_nba_roster_status,
+    },
+    league_player_queries::find_league_player_by_id,
+    player::EligibilityClassification,
+    player_queries::find_player_by_id,
+    sea_orm::DatabaseConnection,
+};
+use fbkl_logic::eligibility;
+
+use super::super::player::{LeagueOrRealPlayer, PlayerSearchKind};
+use crate::graphql::{
+    ErrorCode, LeagueRoleGuard, RoleRequirement, code_error, current_season, graphql_error,
+    require_league_role,
+};
+
+/// §6.2.2 — RFAs are auctioned in the first week only and their original owner may not bid, so the
+/// pool is exposed pre-partitioned rather than as one flat list.
+#[derive(SimpleObject)]
+pub struct VeteranAuctionPool {
+    pub restricted: Vec<LeagueOrRealPlayer>,
+    pub unrestricted: Vec<LeagueOrRealPlayer>,
+    pub free_agents: Vec<LeagueOrRealPlayer>,
+}
+
+#[derive(Default)]
+pub struct EligibilityQuery;
+
+#[Object]
+impl EligibilityQuery {
+    /// Players eligible for the preseason veteran auction, partitioned per §6.2.2.
+    #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Member)")]
+    async fn veteran_auction_pool(
+        &self,
+        ctx: &Context<'_>,
+        end_of_season_year: Option<i16>,
+    ) -> Result<VeteranAuctionPool> {
+        let (league_id, season) = league_and_season(ctx, end_of_season_year).await?;
+        let db = ctx.data_unchecked::<DatabaseConnection>();
+
+        let pool = eligibility::build_veteran_auction_pool(league_id, season, db)
+            .await
+            .map_err(|err| internal("failed to build the veteran auction pool", &err))?;
+
+        Ok(VeteranAuctionPool {
+            restricted: to_graphql(pool.restricted_free_agents),
+            unrestricted: to_graphql(pool.unrestricted_free_agents),
+            free_agents: to_graphql(pool.free_agents),
+        })
+    }
+
+    /// Players eligible for the rookie draft. Prior league draft/ownership is irrelevant (§7.5.3).
+    #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Member)")]
+    async fn rookie_draft_eligible_pool(
+        &self,
+        ctx: &Context<'_>,
+        end_of_season_year: Option<i16>,
+    ) -> Result<Vec<LeagueOrRealPlayer>> {
+        let (league_id, season) = league_and_season(ctx, end_of_season_year).await?;
+        let db = ctx.data_unchecked::<DatabaseConnection>();
+
+        let pool = eligibility::build_rookie_draft_eligible_pool(league_id, season, db)
+            .await
+            .map_err(|err| internal("failed to build the rookie draft pool", &err))?;
+
+        Ok(to_graphql(pool))
+    }
+
+    /// Players signable in-season: both eligible pools minus current rosters (§8.4).
+    #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Member)")]
+    async fn in_season_free_agent_pool(
+        &self,
+        ctx: &Context<'_>,
+        end_of_season_year: Option<i16>,
+    ) -> Result<Vec<LeagueOrRealPlayer>> {
+        let (league_id, season) = league_and_season(ctx, end_of_season_year).await?;
+        let db = ctx.data_unchecked::<DatabaseConnection>();
+
+        let pool = eligibility::build_in_season_fa_pool(league_id, season, db)
+            .await
+            .map_err(|err| internal("failed to build the in-season free agent pool", &err))?;
+
+        Ok(to_graphql(pool))
+    }
+}
+
+#[derive(Default)]
+pub struct EligibilityMutation;
+
+#[Object]
+impl EligibilityMutation {
+    /// Commissioner correction of the NBA-roster *fact* the classification derives from.
+    #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Commissioner)")]
+    async fn set_player_nba_roster_status(
+        &self,
+        ctx: &Context<'_>,
+        kind: PlayerSearchKind,
+        id: i64,
+        has_been_on_nba_roster: bool,
+    ) -> Result<LeagueOrRealPlayer> {
+        let db = ctx.data_unchecked::<DatabaseConnection>();
+        let related_player = load_player_for_commissioner(ctx, kind, id).await?;
+
+        let updated = match related_player {
+            RelatedPlayer::LeaguePlayer(model) => RelatedPlayer::LeaguePlayer(
+                set_league_player_nba_roster_status(model, has_been_on_nba_roster, db)
+                    .await
+                    .map_err(|err| internal("failed to set the NBA roster status", &err))?,
+            ),
+            RelatedPlayer::Player(model) => RelatedPlayer::Player(
+                set_player_nba_roster_status(model, has_been_on_nba_roster, db)
+                    .await
+                    .map_err(|err| internal("failed to set the NBA roster status", &err))?,
+            ),
+        };
+
+        Ok(LeagueOrRealPlayer::from_related_player(updated))
+    }
+
+    /// Commissioner override of the *derived* classification. `classification: null` clears it.
+    #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Commissioner)")]
+    async fn override_player_eligibility(
+        &self,
+        ctx: &Context<'_>,
+        kind: PlayerSearchKind,
+        id: i64,
+        classification: Option<EligibilityClassification>,
+        reason: String,
+    ) -> Result<LeagueOrRealPlayer> {
+        if reason.trim().is_empty() {
+            return Err(graphql_error(
+                ErrorCode::BadRequest,
+                "an eligibility override needs a reason",
+            ));
+        }
+
+        let db = ctx.data_unchecked::<DatabaseConnection>();
+        let (team_user, _) = require_league_role(ctx, RoleRequirement::Commissioner).await?;
+        let related_player = load_player_for_commissioner(ctx, kind, id).await?;
+
+        let updated = match related_player {
+            RelatedPlayer::LeaguePlayer(model) => RelatedPlayer::LeaguePlayer(
+                set_league_player_eligibility_override(
+                    model,
+                    classification,
+                    reason,
+                    team_user.id,
+                    db,
+                )
+                .await
+                .map_err(|err| internal("failed to override eligibility", &err))?,
+            ),
+            RelatedPlayer::Player(model) => RelatedPlayer::Player(
+                set_player_eligibility_override(model, classification, reason, team_user.id, db)
+                    .await
+                    .map_err(|err| internal("failed to override eligibility", &err))?,
+            ),
+        };
+
+        Ok(LeagueOrRealPlayer::from_related_player(updated))
+    }
+}
+
+/// Loads the mutation target, rejecting a league player from another league.
+async fn load_player_for_commissioner(
+    ctx: &Context<'_>,
+    kind: PlayerSearchKind,
+    id: i64,
+) -> Result<RelatedPlayer> {
+    let db = ctx.data_unchecked::<DatabaseConnection>();
+    let (_, caller_team) = require_league_role(ctx, RoleRequirement::Commissioner).await?;
+
+    match kind {
+        PlayerSearchKind::League => {
+            let model = find_league_player_by_id(id, db)
+                .await
+                .map_err(|_| code_error(ErrorCode::NotFound))?;
+            if model.league_id != caller_team.league_id {
+                return Err(code_error(ErrorCode::NotFound));
+            }
+            Ok(RelatedPlayer::LeaguePlayer(model))
+        }
+        PlayerSearchKind::Real => {
+            let model = find_player_by_id(id, db)
+                .await
+                .map_err(|_| code_error(ErrorCode::NotFound))?;
+            Ok(RelatedPlayer::Player(model))
+        }
+    }
+}
+
+/// The caller's league plus the season to build pools for, defaulting to the current one.
+async fn league_and_season(
+    ctx: &Context<'_>,
+    end_of_season_year: Option<i16>,
+) -> Result<(i64, i16)> {
+    let (_, caller_team) = require_league_role(ctx, RoleRequirement::Member).await?;
+    let season = match end_of_season_year {
+        Some(year) => year,
+        None => current_season(ctx, caller_team.league_id).await?,
+    };
+    Ok((caller_team.league_id, season))
+}
+
+fn to_graphql(members: Vec<RelatedPlayer>) -> Vec<LeagueOrRealPlayer> {
+    members
+        .into_iter()
+        .map(LeagueOrRealPlayer::from_related_player)
+        .collect()
+}
+
+fn internal(message: &str, error: &color_eyre::Report) -> async_graphql::Error {
+    tracing::error!(error = ?error, message);
+    code_error(ErrorCode::Internal)
+}

--- a/server/src/graphql/keeper/keeper_resolvers.rs
+++ b/server/src/graphql/keeper/keeper_resolvers.rs
@@ -4,12 +4,10 @@
 //! is deliberately not exposed as a mutation.
 
 use async_graphql::{Context, Error as GraphQlError, Object, Result, SimpleObject};
-use chrono::Utc;
 use color_eyre::Report;
 use fbkl_entity::{
     contract,
     contract_queries::find_contract_by_id,
-    deadline_queries::find_most_recent_deadline_by_datetime,
     sea_orm::{DatabaseConnection, TransactionTrait},
     team,
     team_update_queries::find_team_updates_by_transaction,
@@ -22,7 +20,8 @@ use fbkl_logic::deadline_processing::keeper_deadline::{
 
 use super::super::team::TeamUpdate;
 use crate::graphql::{
-    ErrorCode, LeagueRoleGuard, RoleRequirement, code_error, graphql_error, require_league_role,
+    ErrorCode, LeagueRoleGuard, RoleRequirement, code_error, current_season, graphql_error,
+    require_league_role,
 };
 
 /// Result of a keeper dry-run: whether the submission would be accepted, and why not if it wouldn't.
@@ -58,7 +57,7 @@ impl KeeperQuery {
             None => Some(team_user.team_id),
         };
 
-        let end_of_season_year = current_season(ctx).await?;
+        let end_of_season_year = caller_season(ctx).await?;
         let Some(keeper_transaction) =
             find_keeper_deadline_transaction(caller_team.league_id, end_of_season_year, db)
                 .await
@@ -114,7 +113,7 @@ impl KeeperMutation {
     ) -> Result<TeamUpdate> {
         let db = ctx.data_unchecked::<DatabaseConnection>();
         let (caller_team, contracts) = load_own_keeper_contracts(ctx, &contract_ids).await?;
-        let end_of_season_year = current_season(ctx).await?;
+        let end_of_season_year = caller_season(ctx).await?;
 
         let db_txn = db
             .begin()
@@ -158,16 +157,9 @@ async fn load_own_keeper_contracts(
     Ok((caller_team, contracts))
 }
 
-async fn current_season(ctx: &Context<'_>) -> Result<i16> {
-    let db = ctx.data_unchecked::<DatabaseConnection>();
+async fn caller_season(ctx: &Context<'_>) -> Result<i16> {
     let (_, caller_team) = require_league_role(ctx, RoleRequirement::Member).await?;
-
-    let deadline =
-        find_most_recent_deadline_by_datetime(caller_team.league_id, Utc::now().fixed_offset(), db)
-            .await
-            .map_err(|err| internal("failed to resolve the current deadline", &err))?;
-
-    Ok(deadline.end_of_season_year)
+    current_season(ctx, caller_team.league_id).await
 }
 
 /// A broken keeper rule is the client's fault; anything else is a server fault.

--- a/server/src/graphql/player/player_resolvers.rs
+++ b/server/src/graphql/player/player_resolvers.rs
@@ -1,15 +1,17 @@
 //! Player reads: name search plus single lookups for real (NBA) and league players.
 //!
 //! League players are scoped to the caller's selected league; real players are global NBA
-//! rows and therefore not league-scoped. `playerEligibility(leaguePlayerId)` from spec 06
-//! lands on fbkl-rust-22o (spec 10), which adds the eligibility guard fns in `logic/`.
+//! rows and therefore not league-scoped. `playerEligibility` answers which acquisition pool a
+//! league player belongs to by calling `fbkl_logic::eligibility`, never by re-deriving it here.
 
 use async_graphql::{Context, Enum, Object, Result};
 use fbkl_entity::{
     league_player_queries::{find_league_player_by_id, search_league_players_by_name},
+    player::EligibilityClassification,
     player_queries::{find_player_by_id, search_players_by_name},
     sea_orm::DatabaseConnection,
 };
+use fbkl_logic::eligibility::{PlayerEligibilityFacts, classify_player};
 
 use super::{LeagueOrRealPlayer, LeaguePlayer, RealPlayer};
 use crate::graphql::{
@@ -102,5 +104,26 @@ impl PlayerQuery {
         }
 
         Ok(LeaguePlayer::from_model(model))
+    }
+
+    /// Which acquisition pool a league player belongs to, override included.
+    #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Member)")]
+    async fn player_eligibility(
+        &self,
+        ctx: &Context<'_>,
+        league_player_id: i64,
+    ) -> Result<EligibilityClassification> {
+        let db = ctx.data_unchecked::<DatabaseConnection>();
+        let (_, caller_team) = require_league_role(ctx, RoleRequirement::Member).await?;
+
+        let model = find_league_player_by_id(league_player_id, db)
+            .await
+            .map_err(|_| code_error(ErrorCode::NotFound))?;
+
+        if model.league_id != caller_team.league_id {
+            return Err(code_error(ErrorCode::NotFound));
+        }
+
+        Ok(classify_player(PlayerEligibilityFacts::from(&model)))
     }
 }

--- a/server/src/graphql/player/player_resolvers.rs
+++ b/server/src/graphql/player/player_resolvers.rs
@@ -3,6 +3,9 @@
 //! League players are scoped to the caller's selected league; real players are global NBA
 //! rows and therefore not league-scoped. `playerEligibility` answers which acquisition pool a
 //! league player belongs to by calling `fbkl_logic::eligibility`, never by re-deriving it here.
+//!
+//! Eligibility is per-season, so these resolvers classify for the caller league's current season —
+//! resolved once per call, not per row. `playerEligibility` takes an explicit season to override it.
 
 use async_graphql::{Context, Enum, Object, Result};
 use fbkl_entity::{
@@ -15,7 +18,7 @@ use fbkl_logic::eligibility::{PlayerEligibilityFacts, classify_player};
 
 use super::{LeagueOrRealPlayer, LeaguePlayer, RealPlayer};
 use crate::graphql::{
-    ErrorCode, LeagueRoleGuard, RoleRequirement, code_error, require_league_role,
+    ErrorCode, LeagueRoleGuard, RoleRequirement, code_error, current_season, require_league_role,
 };
 
 /// Bounds each search leg — the real-player table spans every NBA season.
@@ -42,6 +45,7 @@ impl PlayerQuery {
     ) -> Result<Vec<LeagueOrRealPlayer>> {
         let db = ctx.data_unchecked::<DatabaseConnection>();
         let (_, caller_team) = require_league_role(ctx, RoleRequirement::Member).await?;
+        let season = current_season(ctx, caller_team.league_id).await?;
 
         let mut results = vec![];
 
@@ -53,11 +57,9 @@ impl PlayerQuery {
                         tracing::error!(error = ?db_err, "failed to search league players");
                         code_error(ErrorCode::Internal)
                     })?;
-            results.extend(
-                models
-                    .into_iter()
-                    .map(|model| LeagueOrRealPlayer::LeaguePlayer(LeaguePlayer::from_model(model))),
-            );
+            results.extend(models.into_iter().map(|model| {
+                LeagueOrRealPlayer::LeaguePlayer(LeaguePlayer::from_model(model, season))
+            }));
         }
 
         if kind != Some(PlayerSearchKind::League) {
@@ -67,11 +69,9 @@ impl PlayerQuery {
                     tracing::error!(error = ?db_err, "failed to search real players");
                     code_error(ErrorCode::Internal)
                 })?;
-            results.extend(
-                models
-                    .into_iter()
-                    .map(|model| LeagueOrRealPlayer::RealPlayer(RealPlayer::from_model(model))),
-            );
+            results.extend(models.into_iter().map(|model| {
+                LeagueOrRealPlayer::RealPlayer(RealPlayer::from_model(model, season))
+            }));
         }
 
         Ok(results)
@@ -82,11 +82,14 @@ impl PlayerQuery {
     async fn real_player(&self, ctx: &Context<'_>, id: i64) -> Result<RealPlayer> {
         let db = ctx.data_unchecked::<DatabaseConnection>();
 
+        let (_, caller_team) = require_league_role(ctx, RoleRequirement::Member).await?;
+        let season = current_season(ctx, caller_team.league_id).await?;
+
         let model = find_player_by_id(id, db)
             .await
             .map_err(|_| code_error(ErrorCode::NotFound))?;
 
-        Ok(RealPlayer::from_model(model))
+        Ok(RealPlayer::from_model(model, season))
     }
 
     /// A single league player, scoped to the caller's selected league.
@@ -103,15 +106,18 @@ impl PlayerQuery {
             return Err(code_error(ErrorCode::NotFound));
         }
 
-        Ok(LeaguePlayer::from_model(model))
+        let season = current_season(ctx, caller_team.league_id).await?;
+        Ok(LeaguePlayer::from_model(model, season))
     }
 
-    /// Which acquisition pool a league player belongs to, override included.
+    /// Which acquisition pool a league player belongs to, override included. Defaults to the
+    /// league's current season; pass `endOfSeasonYear` to ask about a past one.
     #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Member)")]
     async fn player_eligibility(
         &self,
         ctx: &Context<'_>,
         league_player_id: i64,
+        end_of_season_year: Option<i16>,
     ) -> Result<EligibilityClassification> {
         let db = ctx.data_unchecked::<DatabaseConnection>();
         let (_, caller_team) = require_league_role(ctx, RoleRequirement::Member).await?;
@@ -124,6 +130,13 @@ impl PlayerQuery {
             return Err(code_error(ErrorCode::NotFound));
         }
 
-        Ok(classify_player(PlayerEligibilityFacts::from(&model)))
+        let season = match end_of_season_year {
+            Some(year) => year,
+            None => current_season(ctx, caller_team.league_id).await?,
+        };
+        Ok(classify_player(
+            PlayerEligibilityFacts::from(&model),
+            season,
+        ))
     }
 }

--- a/server/src/graphql/player/player_types.rs
+++ b/server/src/graphql/player/player_types.rs
@@ -1,6 +1,11 @@
-use async_graphql::{Context, Object, Result, Union, dataloader::DataLoader};
+use async_graphql::{Context, Object, Result, SimpleObject, Union, dataloader::DataLoader};
 use color_eyre::eyre::eyre;
-use fbkl_entity::{league_player, player};
+use fbkl_entity::{
+    contract::RelatedPlayer,
+    league_player,
+    player::{self, EligibilityClassification, NbaRosterSource},
+};
+use fbkl_logic::eligibility::{PlayerEligibilityFacts, classify_player};
 
 use crate::{
     error::FbklError,
@@ -13,23 +18,68 @@ pub enum LeagueOrRealPlayer {
     RealPlayer(RealPlayer),
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+impl LeagueOrRealPlayer {
+    /// Pool builders and contracts both hand back entity's `RelatedPlayer`.
+    pub fn from_related_player(related_player: RelatedPlayer) -> Self {
+        match related_player {
+            RelatedPlayer::LeaguePlayer(model) => {
+                Self::LeaguePlayer(LeaguePlayer::from_model(model))
+            }
+            RelatedPlayer::Player(model) => Self::RealPlayer(RealPlayer::from_model(model)),
+        }
+    }
+}
+
+/// The spec-10 eligibility columns shared by both player types, plus the derived classification.
+#[derive(Clone, Debug, Eq, PartialEq, SimpleObject)]
+pub struct PlayerEligibility {
+    pub classification: EligibilityClassification,
+    pub has_been_on_nba_roster: bool,
+    pub nba_roster_source: NbaRosterSource,
+    pub nba_roster_asof: Option<String>,
+    pub eligibility_override: Option<EligibilityClassification>,
+}
+
+impl PlayerEligibility {
+    fn from_league_player(entity: &league_player::Model) -> Self {
+        Self {
+            classification: classify_player(PlayerEligibilityFacts::from(entity)),
+            has_been_on_nba_roster: entity.has_been_on_nba_roster,
+            nba_roster_source: entity.nba_roster_source,
+            nba_roster_asof: entity.nba_roster_asof.map(|asof| asof.to_rfc3339()),
+            eligibility_override: entity.eligibility_override,
+        }
+    }
+
+    fn from_player(entity: &player::Model) -> Self {
+        Self {
+            classification: classify_player(PlayerEligibilityFacts::from(entity)),
+            has_been_on_nba_roster: entity.has_been_on_nba_roster,
+            nba_roster_source: entity.nba_roster_source,
+            nba_roster_asof: entity.nba_roster_asof.map(|asof| asof.to_rfc3339()),
+            eligibility_override: entity.eligibility_override,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LeaguePlayer {
     pub id: i64,
     pub is_rdi_eligible: bool,
     pub name: String,
     pub real_player_id: Option<i64>,
-    // pub real_player: Option<RealPlayer>,
+    pub eligibility: PlayerEligibility,
 }
 
 impl LeaguePlayer {
     pub fn from_model(entity: league_player::Model) -> Self {
+        let eligibility = PlayerEligibility::from_league_player(&entity);
         Self {
             id: entity.id,
             is_rdi_eligible: entity.is_rdi_eligible,
             name: entity.name,
             real_player_id: entity.real_player_id,
-            // real_player: None,
+            eligibility,
         }
     }
 }
@@ -52,6 +102,10 @@ impl LeaguePlayer {
         self.real_player_id
     }
 
+    async fn eligibility(&self) -> PlayerEligibility {
+        self.eligibility.clone()
+    }
+
     async fn real_player(&self, ctx: &Context<'_>) -> Result<Option<RealPlayer>, FbklError> {
         match self.real_player_id {
             Some(real_player_id) => {
@@ -68,7 +122,7 @@ impl LeaguePlayer {
     }
 }
 
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct RealPlayer {
     pub id: i64,
     pub is_rdi_eligible: bool,
@@ -78,11 +132,13 @@ pub struct RealPlayer {
     pub position_id: i32,
     // pub position: String,
     pub real_team_id: i64,
+    pub eligibility: PlayerEligibility,
     // pub real_team_name: String,
 }
 
 impl RealPlayer {
     pub fn from_model(entity: player::Model) -> Self {
+        let eligibility = PlayerEligibility::from_player(&entity);
         Self {
             id: entity.id,
             is_rdi_eligible: entity.is_rdi_eligible,
@@ -92,6 +148,7 @@ impl RealPlayer {
             position_id: entity.position_id,
             // position: "".to_string(),
             real_team_id: entity.current_real_team_id,
+            eligibility,
             // real_team_name: "".to_string(),
         }
     }
@@ -135,6 +192,10 @@ impl RealPlayer {
 
     async fn real_team_id(&self) -> i64 {
         self.real_team_id
+    }
+
+    async fn eligibility(&self) -> PlayerEligibility {
+        self.eligibility.clone()
     }
 
     async fn real_team_name(&self, ctx: &Context<'_>) -> Result<String, FbklError> {

--- a/server/src/graphql/player/player_types.rs
+++ b/server/src/graphql/player/player_types.rs
@@ -19,42 +19,61 @@ pub enum LeagueOrRealPlayer {
 }
 
 impl LeagueOrRealPlayer {
-    /// Pool builders and contracts both hand back entity's `RelatedPlayer`.
-    pub fn from_related_player(related_player: RelatedPlayer) -> Self {
+    /// Pool builders and contracts both hand back entity's `RelatedPlayer`. `end_of_season_year` is
+    /// the season the classification is asked about — the pool's season, or the contract's.
+    pub fn from_related_player(related_player: RelatedPlayer, end_of_season_year: i16) -> Self {
         match related_player {
             RelatedPlayer::LeaguePlayer(model) => {
-                Self::LeaguePlayer(LeaguePlayer::from_model(model))
+                Self::LeaguePlayer(LeaguePlayer::from_model(model, end_of_season_year))
             }
-            RelatedPlayer::Player(model) => Self::RealPlayer(RealPlayer::from_model(model)),
+            RelatedPlayer::Player(model) => {
+                Self::RealPlayer(RealPlayer::from_model(model, end_of_season_year))
+            }
         }
     }
 }
 
-/// The spec-10 eligibility columns shared by both player types, plus the derived classification.
+/// The spec-10 eligibility columns shared by both player types, plus the classification derived for
+/// `classifiedForEndOfSeasonYear` — eligibility is per-season, so the answer is stamped with the
+/// season it answers for.
 #[derive(Clone, Debug, Eq, PartialEq, SimpleObject)]
 pub struct PlayerEligibility {
     pub classification: EligibilityClassification,
-    pub has_been_on_nba_roster: bool,
+    pub classified_for_end_of_season_year: i16,
+    /// §3.1.2, over the player's whole career. Narrowed to a season by `nbaFirstSeason...`.
+    pub has_played_nba_game: bool,
+    /// The season the player first appeared in NBA data. `<=` a season is the §3.1.3 RDI fact.
+    pub nba_first_season_end_of_season_year: Option<i16>,
     pub nba_roster_source: NbaRosterSource,
     pub nba_roster_asof: Option<String>,
     pub eligibility_override: Option<EligibilityClassification>,
 }
 
 impl PlayerEligibility {
-    fn from_league_player(entity: &league_player::Model) -> Self {
+    fn from_league_player(entity: &league_player::Model, end_of_season_year: i16) -> Self {
         Self {
-            classification: classify_player(PlayerEligibilityFacts::from(entity)),
-            has_been_on_nba_roster: entity.has_been_on_nba_roster,
+            classification: classify_player(
+                PlayerEligibilityFacts::from(entity),
+                end_of_season_year,
+            ),
+            classified_for_end_of_season_year: end_of_season_year,
+            has_played_nba_game: entity.has_played_nba_game,
+            nba_first_season_end_of_season_year: entity.nba_first_season_end_of_season_year,
             nba_roster_source: entity.nba_roster_source,
             nba_roster_asof: entity.nba_roster_asof.map(|asof| asof.to_rfc3339()),
             eligibility_override: entity.eligibility_override,
         }
     }
 
-    fn from_player(entity: &player::Model) -> Self {
+    fn from_player(entity: &player::Model, end_of_season_year: i16) -> Self {
         Self {
-            classification: classify_player(PlayerEligibilityFacts::from(entity)),
-            has_been_on_nba_roster: entity.has_been_on_nba_roster,
+            classification: classify_player(
+                PlayerEligibilityFacts::from(entity),
+                end_of_season_year,
+            ),
+            classified_for_end_of_season_year: end_of_season_year,
+            has_played_nba_game: entity.has_played_nba_game,
+            nba_first_season_end_of_season_year: entity.nba_first_season_end_of_season_year,
             nba_roster_source: entity.nba_roster_source,
             nba_roster_asof: entity.nba_roster_asof.map(|asof| asof.to_rfc3339()),
             eligibility_override: entity.eligibility_override,
@@ -72,8 +91,8 @@ pub struct LeaguePlayer {
 }
 
 impl LeaguePlayer {
-    pub fn from_model(entity: league_player::Model) -> Self {
-        let eligibility = PlayerEligibility::from_league_player(&entity);
+    pub fn from_model(entity: league_player::Model, end_of_season_year: i16) -> Self {
+        let eligibility = PlayerEligibility::from_league_player(&entity, end_of_season_year);
         Self {
             id: entity.id,
             is_rdi_eligible: entity.is_rdi_eligible,
@@ -115,7 +134,10 @@ impl LeaguePlayer {
                     .await
                     .map_err(|error| eyre!("{error}"))?
                     .ok_or_else(|| eyre!("player {real_player_id} not found"))?;
-                Ok(Some(RealPlayer::from_model(real_player)))
+                Ok(Some(RealPlayer::from_model(
+                    real_player,
+                    self.eligibility.classified_for_end_of_season_year,
+                )))
             }
             None => Ok(None),
         }
@@ -137,8 +159,8 @@ pub struct RealPlayer {
 }
 
 impl RealPlayer {
-    pub fn from_model(entity: player::Model) -> Self {
-        let eligibility = PlayerEligibility::from_player(&entity);
+    pub fn from_model(entity: player::Model, end_of_season_year: i16) -> Self {
+        let eligibility = PlayerEligibility::from_player(&entity, end_of_season_year);
         Self {
             id: entity.id,
             is_rdi_eligible: entity.is_rdi_eligible,

--- a/server/src/graphql/season.rs
+++ b/server/src/graphql/season.rs
@@ -1,0 +1,24 @@
+//! Resolving "which season is it?" for resolvers whose arguments leave it implicit.
+//!
+//! The league's deadline schedule is the source of truth: the most recent deadline that has
+//! already passed names the current `end_of_season_year`.
+
+use async_graphql::{Context, Result};
+use chrono::Utc;
+use fbkl_entity::{
+    deadline_queries::find_most_recent_deadline_by_datetime, sea_orm::DatabaseConnection,
+};
+
+use super::error::{ErrorCode, code_error};
+
+pub async fn current_season(ctx: &Context<'_>, league_id: i64) -> Result<i16> {
+    let db = ctx.data_unchecked::<DatabaseConnection>();
+    let deadline = find_most_recent_deadline_by_datetime(league_id, Utc::now().fixed_offset(), db)
+        .await
+        .map_err(|err| {
+            tracing::error!(error = ?err, league_id, "failed to resolve the current season");
+            code_error(ErrorCode::Internal)
+        })?;
+
+    Ok(deadline.end_of_season_year)
+}


### PR DESCRIPTION
Implements `notes/implementation-specs/10-eligibility-and-player-pool.md` (backend).

**Stack position: 2 of 4.** Based on `feat/56c-graphql-api-surface` (#85) — **review/merge that first**; this PR's diff is against it, not `main`.

⚠️ **Also depends on a submodule PR:** `import-data` is a git submodule and this branch bumps its pointer. Merge kaibyao/fbkl-rust-import-data#5 first, or the pointer dangles for anyone else checking this out.

## The one fact everything hangs on — and it was the wrong fact

The league splits players into two acquisition pools by a single question, and the rules document had it backwards. §3.1.2 defined the pivot as *"having been on an active NBA roster"* and said outright that game minutes were not required. That is not how the league actually decides: eligibility turns on whether the player has **appeared in an in-season NBA game**.

So this PR corrects the rules document too (`notes/2025-08-31-rules_document.md`): §3.1.2 is rewritten, and the eight places that used the roster phrasing for pool purposes are reworded (§6.2.1, §7.5.1.3–.6, §7.5.2.1, §7.5.3, §8.4.1, §9.2.1, §14.4.1).

The roster fact is still needed, so it becomes a new **§3.1.3 scoped to RDI only** — §11.3.1 forces RDI→RD/1 as soon as a player is "on an NBA roster / signed to an NBA contract", whether or not he ever plays. A rostered player who never appeared is therefore still rookie-draft-eligible but already RDI-ineligible. Both facts have to be stored; neither subsumes the other.

## Eligibility is a question about a season

Migration `m20260725_000001_add_player_eligibility_fields` adds to **both** `player` and `league_player`:

| Column | Rule | Meaning |
|---|---|---|
| `has_played_nba_game` | §3.1.2 | ever appeared in a game, over the whole career |
| `nba_first_season_end_of_season_year` | §3.1.3 | season he first appeared in NBA data, `None` for never |
| `nba_roster_source` / `nba_roster_asof` | — | provenance and freshness; `asof IS NULL` means never ingested |
| `eligibility_override` + audit fields | §3.1.2 / §11.3.6 | commissioner override, reason required |

Career booleans were wrong twice over. They **rejected legal history** — replaying Leandro Bolmaro's 2020-12-19 RD→RDI (contract 7685, EoSY 2021) failed, because his stored facts describe a player who debuted in EoSY 2022 and so classified as a veteran. And the pool builders already accepted an `end_of_season_year` while classifying on career facts, so asking for a past season's veteran auction quietly returned *today's* answer.

`logic` therefore exposes `was_on_nba_roster_before(season)` and `had_played_nba_game_before(season)`, and every caller states the season it means: contract guards pass the contract's, pool builders the pool's, player lookups the league's current season resolved once per call rather than per row. `PlayerEligibility` reports `classifiedForEndOfSeasonYear` so a cached client cannot mistake the answer for timeless, and `playerEligibility` takes an optional season.

`EligibilityClassification` stays **derived, not stored** — only the override is persisted. `PlayerStatus { Active, Retired }` is left alone; it answers "show in search?", a different question.

## Why the comparison is strictly earlier

`nba_first_season_...` is season-granular, but the rules turn on *where in* a season a player arrived. §11.3.5 gives an RDI who lands on an NBA roster mid-season until the **next** legalization to move — so same-or-earlier rejects exactly the legalization the rule protects. It fails 2 of the 25 historical RD→RDI moves: **Tristan Vukcevic** (signed with Washington in March 2024) and **Saliou Niang** (draft-and-stash, listed under his draft season).

The tradeoff, stated plainly: within a season the stamp cannot tell a July signing from a March one, so a player signed *before* the season starts gets a grace period he isn't strictly owed. That is the deliberate direction to err — a guard should not reject history that was legal.

## Guards this closes

`logic/CLAUDE.md` convention 4 documented that `rookie_development_activation` and `rookie_development_international` *skipped* the pre-mutation validation that `ir`/`drop_contract` perform — flagged in the file as "a known inconsistency, not a pattern to copy". All three now validate:

- RD activation: kind is RD/RDI, contract Active and latest-in-chain
- RD→RDI: kind is RD **and** the player passes `validate_rdi_eligible`
- RDI→RD: kind only — moving *out* of international is always legal (§11.3.1 forced transition), so deliberately no eligibility gate

The convention-4 note is updated, since it no longer holds.

## Reviewer notes

- `validate_rdi_eligible`'s "not formerly a post-legalization RD contract" test is a **documented proxy**: it treats an RD contract past year 1, or an RD contract from an earlier season, as having crossed a legalization. Reading legalization events directly needs data spec 10 lists as an open question. Named as a proxy in the doc comment at `logic/src/eligibility/rdi.rs`.
- The `has_played_nba_game` fact comes from the NBA index's career `PTS` being non-null — see the submodule PR for why that holds and how the importer aborts if it stops holding.
- **Known gap:** the checked-in database dump's `player` COPY predates these columns, so a dump-loaded database leaves them empty and the pools read wrong until a player import fills them in. `nba_roster_asof IS NULL` is the marker.

## Verification

`cargo fmt --all --check` clean · `clippy --workspace --all-targets -D warnings` 0 warnings · `nextest` 68/68 · doctests pass · `cd import-data && cargo clippy --all-targets -- -D warnings` clean (excluded from the workspace, so checked separately) · SDL + codegen no drift · `tsc` and `oxlint` clean · migration `up` **and** `down` verified against a scratch Postgres.

End-to-end against a real database — the whole point, since this started as an import failure:

- full transaction replay to completion, **25 of 25** RD→RDI moves land (including contract 7685, the one that used to fail)
- 14622 contracts through EoSY 2026, **0** duplicate active contracts
- Bolmaro's chain replays as `RD/1 2021 → RDI/1 2021 → RDI/2 2022 → RD/1 2022 → Rookie/1 2022`, matching the source transaction history

Closes fbkl-rust-22o, fbkl-rust-rse, fbkl-rust-vaa.

https://claude.ai/code/session_013HAA7xG3vi5zUMCXABDus6
