### PR TITLE
feat(rookie-draft): order, lottery, and live selections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1424,6 +1424,7 @@ dependencies = [
  "fbkl-entity",
  "multimap 0.9.1",
  "once_cell",
+ "rand 0.8.6",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1450,6 +1450,7 @@ dependencies = [
  "color-eyre",
  "dotenv",
  "fbkl-auth",
+ "fbkl-constants",
  "fbkl-entity",
  "fbkl-jobs",
  "fbkl-logic",

--- a/constants/src/league_rules/config_settings.rs
+++ b/constants/src/league_rules/config_settings.rs
@@ -52,3 +52,57 @@ pub static LEAGUE_TIME_ZONE_UTC_OFFSET_SECONDS: i32 = -6 * 3600;
 pub static IN_SEASON_FA_OPENING_BID_DEADLINE_HOUR_MINUTE: (u32, u32) = (23, 59);
 /// Sunday 8pm CT: the weekly all-bid deadline every open in-season FA auction ends at (rules §8.2).
 pub static IN_SEASON_FA_ALL_BID_DEADLINE_HOUR_MINUTE: (u32, u32) = (20, 0);
+/// Fixed Rookie-Development contract salary for a rookie drafted in the given round (rules §7.4.1).
+/// Index 0 = round 1. Rounds 1–5 → $4/$3/$2/$1/$1.
+pub static ROOKIE_DRAFT_ROUND_SALARIES: [i16; 5] = [4, 3, 2, 1, 1];
+/// Lottery balls per non-playoff seed, worst → best (rules §7.2.4). 6 non-playoff seeds.
+pub static ROOKIE_DRAFT_LOTTERY_BALLS: [u32; 6] = [6, 5, 4, 3, 2, 1];
+
+/// Rookie-Development salary for a 1-based rookie draft round (rules §7.4.1).
+///
+/// # Panics
+/// Panics if `round` is outside 1..=[`DRAFT_PICK_ROUNDS`]; a draft round out of range is a
+/// programmer error, not a recoverable condition.
+#[must_use]
+pub fn rookie_draft_salary_for_round(round: i16) -> i16 {
+    round
+        .checked_sub(1)
+        .and_then(|index| usize::try_from(index).ok())
+        .and_then(|index| ROOKIE_DRAFT_ROUND_SALARIES.get(index).copied())
+        .unwrap_or_else(|| {
+            panic!("Rookie draft round ({round}) is outside 1..={DRAFT_PICK_ROUNDS}.")
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DRAFT_PICK_ROUNDS, ROOKIE_DRAFT_ROUND_SALARIES, rookie_draft_salary_for_round};
+
+    #[test]
+    fn salary_for_each_valid_round() {
+        assert_eq!(
+            (1..=DRAFT_PICK_ROUNDS)
+                .map(rookie_draft_salary_for_round)
+                .collect::<Vec<_>>(),
+            ROOKIE_DRAFT_ROUND_SALARIES.to_vec()
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "Rookie draft round (0) is outside 1..=5.")]
+    fn round_zero_panics() {
+        let _ = rookie_draft_salary_for_round(0);
+    }
+
+    #[test]
+    #[should_panic(expected = "Rookie draft round (6) is outside 1..=5.")]
+    fn round_past_last_round_panics() {
+        let _ = rookie_draft_salary_for_round(6);
+    }
+
+    #[test]
+    #[should_panic(expected = "Rookie draft round (-1) is outside 1..=5.")]
+    fn negative_round_panics() {
+        let _ = rookie_draft_salary_for_round(-1);
+    }
+}

--- a/entity/src/entities/league_team_season_standing.rs
+++ b/entity/src/entities/league_team_season_standing.rs
@@ -1,0 +1,61 @@
+//! A team's frozen standings inputs for one season, ingested from the external league host (§7.2).
+//!
+//! The rookie draft reads these rather than computing them: `mid_season_rank` is the ≈2/3-season
+//! snapshot (§7.2.3) that sets lottery odds and the rounds 2–5 order, `regular_season_rank` is the
+//! final standings used as a tie-break, and `playoff_finish` orders the playoff teams.
+
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "league_team_season_standing")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub league_id: i64,
+    pub team_id: i64,
+    pub end_of_season_year: i16,
+    /// Final regular-season standings rank, 1 = best.
+    pub regular_season_rank: i16,
+    /// The ≈2/3-season snapshot rank, 1 = best.
+    pub mid_season_rank: i16,
+    pub made_playoffs: bool,
+    /// 1 = champion … 6 = first-round loser. NULL for non-playoff teams.
+    pub playoff_finish: Option<i16>,
+    pub created_at: DateTimeWithTimeZone,
+    pub updated_at: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::league::Entity",
+        from = "Column::LeagueId",
+        to = "super::league::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    League,
+    #[sea_orm(
+        belongs_to = "super::team::Entity",
+        from = "Column::TeamId",
+        to = "super::team::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    Team,
+}
+
+impl Related<super::league::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::League.def()
+    }
+}
+
+impl Related<super::team::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Team.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/entity/src/entities/mod.rs
+++ b/entity/src/entities/mod.rs
@@ -11,6 +11,7 @@ pub mod draft_pick_option;
 pub mod job_run;
 pub mod league;
 pub mod league_player;
+pub mod league_team_season_standing;
 pub mod min_bid_tier_config;
 pub mod player;
 pub mod position;

--- a/entity/src/entities/mod.rs
+++ b/entity/src/entities/mod.rs
@@ -16,6 +16,8 @@ pub mod min_bid_tier_config;
 pub mod player;
 pub mod position;
 pub mod real_team;
+pub mod rookie_draft_lottery;
+pub mod rookie_draft_lottery_pick;
 pub mod rookie_draft_selection;
 pub mod sessions;
 pub mod team;

--- a/entity/src/entities/rookie_draft_lottery.rs
+++ b/entity/src/entities/rookie_draft_lottery.rs
@@ -1,0 +1,50 @@
+//! One row per league season recording the rookie draft lottery draw (rules §7.2.4-§7.2.5).
+//!
+//! `rng_seed` is stored when the row is created, before the draw is revealed (commit-reveal), so
+//! owners can re-run the draw themselves and confirm it was not re-rolled. `rng_log` is the
+//! human-readable per-draw record of who held how many balls.
+
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "rookie_draft_lottery")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub league_id: i64,
+    pub end_of_season_year: i16,
+    /// Seed handed to `StdRng::seed_from_u64`, committed before the draw.
+    pub rng_seed: i64,
+    pub rng_log: Option<String>,
+    pub created_at: DateTimeWithTimeZone,
+    pub updated_at: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::league::Entity",
+        from = "Column::LeagueId",
+        to = "super::league::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    League,
+    #[sea_orm(has_many = "super::rookie_draft_lottery_pick::Entity")]
+    RookieDraftLotteryPick,
+}
+
+impl Related<super::league::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::League.def()
+    }
+}
+
+impl Related<super::rookie_draft_lottery_pick::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::RookieDraftLotteryPick.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/entity/src/entities/rookie_draft_lottery_pick.rs
+++ b/entity/src/entities/rookie_draft_lottery_pick.rs
@@ -1,0 +1,57 @@
+//! One row per drawn first-round lottery slot, picks 1-6 (rules §7.2.5).
+//!
+//! `balls_held` is what the team held at the moment of its draw, which is the audit trail for the
+//! weighting. Picks 7-12 are deterministic from `playoff_finish` and are not stored here.
+
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Eq, DeriveEntityModel, Serialize, Deserialize)]
+#[sea_orm(table_name = "rookie_draft_lottery_pick")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i64,
+    pub rookie_draft_lottery_id: i64,
+    /// 1-6, the first-round pick this draw won.
+    pub pick_number: i16,
+    /// The non-playoff team whose standings slot won the draw; the pick itself goes to whoever
+    /// currently owns that team's first-round pick.
+    pub team_id: i64,
+    pub balls_held: i16,
+    pub created_at: DateTimeWithTimeZone,
+    pub updated_at: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::rookie_draft_lottery::Entity",
+        from = "Column::RookieDraftLotteryId",
+        to = "super::rookie_draft_lottery::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    RookieDraftLottery,
+    #[sea_orm(
+        belongs_to = "super::team::Entity",
+        from = "Column::TeamId",
+        to = "super::team::Column::Id",
+        on_update = "Cascade",
+        on_delete = "Cascade"
+    )]
+    Team,
+}
+
+impl Related<super::rookie_draft_lottery::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::RookieDraftLottery.def()
+    }
+}
+
+impl Related<super::team::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Team.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/entity/src/entities/rookie_draft_selection.rs
+++ b/entity/src/entities/rookie_draft_selection.rs
@@ -14,6 +14,9 @@ pub struct Model {
     pub contract_id: Option<i64>,
     pub draft_pick_id: i64,
     pub league_id: i64,
+    /// Denormalized from `draft_pick.current_owner_team_id` when the slate is built, so a traded
+    /// pick is made by the acquirer (rules §7.2.1 orders by original owner, §12.4 allows trading).
+    pub current_owner_team_id: i64,
     /// The rookie-draft-selection transaction, set when the pick is recorded (1:1).
     pub transaction_id: Option<i64>,
 }
@@ -23,6 +26,7 @@ impl Model {
         league_id: i64,
         contract_id: i64,
         draft_pick_id: i64,
+        current_owner_team_id: i64,
         order: i16,
     ) -> ActiveModel {
         ActiveModel {
@@ -32,6 +36,7 @@ impl Model {
             contract_id: ActiveValue::Set(Some(contract_id)),
             draft_pick_id: ActiveValue::Set(draft_pick_id),
             league_id: ActiveValue::Set(league_id),
+            current_owner_team_id: ActiveValue::Set(current_owner_team_id),
             transaction_id: ActiveValue::NotSet,
         }
     }

--- a/entity/src/queries/draft_pick_queries.rs
+++ b/entity/src/queries/draft_pick_queries.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-use color_eyre::Result;
+use color_eyre::eyre::{Result, eyre};
 use sea_orm::{
     ActiveModelTrait, ColumnTrait, ConnectionTrait, EntityTrait, LoaderTrait, QueryFilter,
     QueryOrder, TransactionTrait,
@@ -50,6 +50,17 @@ where
         .collect();
 
     Ok(related_draft_picks)
+}
+
+#[instrument]
+pub async fn find_draft_pick_by_id<C>(draft_pick_id: i64, db: &C) -> Result<draft_pick::Model>
+where
+    C: ConnectionTrait + Debug,
+{
+    draft_pick::Entity::find_by_id(draft_pick_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| eyre!("Could not find draft pick ({draft_pick_id})."))
 }
 
 #[instrument]

--- a/entity/src/queries/league_team_season_standing_queries.rs
+++ b/entity/src/queries/league_team_season_standing_queries.rs
@@ -1,0 +1,95 @@
+//! Reads/writes for the frozen per-season standings inputs the rookie draft consumes (rules §7.2).
+
+use std::fmt::Debug;
+
+use color_eyre::Result;
+use sea_orm::{
+    ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder,
+    sea_query::OnConflict,
+};
+use tracing::instrument;
+
+use crate::league_team_season_standing;
+
+/// One team's standings inputs as entered by the commissioner.
+#[derive(Clone, Copy, Debug)]
+pub struct NewLeagueTeamSeasonStanding {
+    pub team_id: i64,
+    pub regular_season_rank: i16,
+    pub mid_season_rank: i16,
+    pub made_playoffs: bool,
+    pub playoff_finish: Option<i16>,
+}
+
+/// Every team's standings row for the season, best final rank first.
+#[instrument]
+pub async fn find_standings_for_league_season<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    db: &C,
+) -> Result<Vec<league_team_season_standing::Model>>
+where
+    C: ConnectionTrait + Debug,
+{
+    let standing_models = league_team_season_standing::Entity::find()
+        .filter(league_team_season_standing::Column::LeagueId.eq(league_id))
+        .filter(league_team_season_standing::Column::EndOfSeasonYear.eq(end_of_season_year))
+        .order_by_asc(league_team_season_standing::Column::RegularSeasonRank)
+        .all(db)
+        .await?;
+    Ok(standing_models)
+}
+
+/// Upserts the season's standings rows, replacing any prior entry for the same team.
+///
+/// Re-entry is allowed until the draft starts (the commissioner may fix a typo); once the lottery
+/// has run the draft order is already persisted, so later edits do not move picks.
+#[instrument(skip(rows))]
+pub async fn upsert_standings_for_league_season<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    rows: Vec<NewLeagueTeamSeasonStanding>,
+    db: &C,
+) -> Result<()>
+where
+    C: ConnectionTrait + Debug,
+{
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    let models_to_insert = rows
+        .into_iter()
+        .map(|row| league_team_season_standing::ActiveModel {
+            id: ActiveValue::NotSet,
+            league_id: ActiveValue::Set(league_id),
+            team_id: ActiveValue::Set(row.team_id),
+            end_of_season_year: ActiveValue::Set(end_of_season_year),
+            regular_season_rank: ActiveValue::Set(row.regular_season_rank),
+            mid_season_rank: ActiveValue::Set(row.mid_season_rank),
+            made_playoffs: ActiveValue::Set(row.made_playoffs),
+            playoff_finish: ActiveValue::Set(row.playoff_finish),
+            created_at: ActiveValue::NotSet,
+            updated_at: ActiveValue::NotSet,
+        });
+
+    league_team_season_standing::Entity::insert_many(models_to_insert)
+        .on_conflict(
+            OnConflict::columns([
+                league_team_season_standing::Column::LeagueId,
+                league_team_season_standing::Column::EndOfSeasonYear,
+                league_team_season_standing::Column::TeamId,
+            ])
+            .update_columns([
+                league_team_season_standing::Column::RegularSeasonRank,
+                league_team_season_standing::Column::MidSeasonRank,
+                league_team_season_standing::Column::MadePlayoffs,
+                league_team_season_standing::Column::PlayoffFinish,
+            ])
+            .to_owned(),
+        )
+        .exec(db)
+        .await?;
+
+    Ok(())
+}

--- a/entity/src/queries/mod.rs
+++ b/entity/src/queries/mod.rs
@@ -12,6 +12,7 @@ pub mod pagination;
 pub mod player_queries;
 pub mod position_queries;
 pub mod real_team_queries;
+pub mod rookie_draft_lottery_queries;
 pub mod rookie_draft_selection_queries;
 pub mod team_queries;
 pub mod team_update_queries;

--- a/entity/src/queries/mod.rs
+++ b/entity/src/queries/mod.rs
@@ -7,6 +7,7 @@ pub mod eligibility_queries;
 pub mod job_run_queries;
 pub mod league_player_queries;
 pub mod league_queries;
+pub mod league_team_season_standing_queries;
 pub mod pagination;
 pub mod player_queries;
 pub mod position_queries;

--- a/entity/src/queries/rookie_draft_lottery_queries.rs
+++ b/entity/src/queries/rookie_draft_lottery_queries.rs
@@ -1,0 +1,146 @@
+//! Reads/writes for the rookie draft lottery audit rows (rules §7.2.4-§7.2.5).
+//!
+//! The seed row is written before the draw happens (commit-reveal) and the drawn slots are written
+//! after, so a stored lottery is proof the order was not re-rolled.
+
+use std::fmt::Debug;
+
+use color_eyre::Result;
+use sea_orm::{
+    ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait, QueryFilter, QueryOrder,
+    sea_query::OnConflict,
+};
+use tracing::instrument;
+
+use crate::{rookie_draft_lottery, rookie_draft_lottery_pick};
+
+/// One drawn first-round slot, with the ball count that won it.
+#[derive(Clone, Copy, Debug)]
+pub struct NewRookieDraftLotteryPick {
+    pub pick_number: i16,
+    pub team_id: i64,
+    pub balls_held: i16,
+}
+
+/// The league season's lottery row, if one has been created.
+#[instrument]
+pub async fn find_lottery_for_league_season<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    db: &C,
+) -> Result<Option<rookie_draft_lottery::Model>>
+where
+    C: ConnectionTrait + Debug,
+{
+    let lottery_model = rookie_draft_lottery::Entity::find()
+        .filter(rookie_draft_lottery::Column::LeagueId.eq(league_id))
+        .filter(rookie_draft_lottery::Column::EndOfSeasonYear.eq(end_of_season_year))
+        .one(db)
+        .await?;
+    Ok(lottery_model)
+}
+
+/// The drawn slots for a lottery, pick 1 first.
+#[instrument]
+pub async fn find_lottery_picks<C>(
+    rookie_draft_lottery_id: i64,
+    db: &C,
+) -> Result<Vec<rookie_draft_lottery_pick::Model>>
+where
+    C: ConnectionTrait + Debug,
+{
+    let pick_models = rookie_draft_lottery_pick::Entity::find()
+        .filter(rookie_draft_lottery_pick::Column::RookieDraftLotteryId.eq(rookie_draft_lottery_id))
+        .order_by_asc(rookie_draft_lottery_pick::Column::PickNumber)
+        .all(db)
+        .await?;
+    Ok(pick_models)
+}
+
+/// Commits the seed for a league season's lottery, or returns the existing row if already committed.
+#[instrument]
+pub async fn insert_lottery_seed<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    rng_seed: i64,
+    db: &C,
+) -> Result<rookie_draft_lottery::Model>
+where
+    C: ConnectionTrait + Debug,
+{
+    let lottery_to_insert = rookie_draft_lottery::ActiveModel {
+        id: ActiveValue::NotSet,
+        league_id: ActiveValue::Set(league_id),
+        end_of_season_year: ActiveValue::Set(end_of_season_year),
+        rng_seed: ActiveValue::Set(rng_seed),
+        rng_log: ActiveValue::NotSet,
+        created_at: ActiveValue::NotSet,
+        updated_at: ActiveValue::NotSet,
+    };
+
+    // Do-nothing conflict + re-read: a committed seed is never overwritten.
+    rookie_draft_lottery::Entity::insert(lottery_to_insert)
+        .on_conflict(
+            OnConflict::columns([
+                rookie_draft_lottery::Column::LeagueId,
+                rookie_draft_lottery::Column::EndOfSeasonYear,
+            ])
+            .do_nothing()
+            .to_owned(),
+        )
+        .exec_without_returning(db)
+        .await?;
+
+    let lottery_model = find_lottery_for_league_season(league_id, end_of_season_year, db)
+        .await?
+        .ok_or_else(|| {
+            color_eyre::eyre::eyre!(
+                "lottery row for league ({league_id}) season ({end_of_season_year}) missing right after insert."
+            )
+        })?;
+    Ok(lottery_model)
+}
+
+/// Reveals a committed lottery: stores the drawn slots and the per-draw audit log.
+#[instrument(skip(drawn_picks))]
+pub async fn save_lottery_draw<C>(
+    rookie_draft_lottery_id: i64,
+    drawn_picks: Vec<NewRookieDraftLotteryPick>,
+    rng_log: String,
+    db: &C,
+) -> Result<()>
+where
+    C: ConnectionTrait + Debug,
+{
+    if drawn_picks.is_empty() {
+        return Ok(());
+    }
+
+    let picks_to_insert =
+        drawn_picks
+            .into_iter()
+            .map(|drawn_pick| rookie_draft_lottery_pick::ActiveModel {
+                id: ActiveValue::NotSet,
+                rookie_draft_lottery_id: ActiveValue::Set(rookie_draft_lottery_id),
+                pick_number: ActiveValue::Set(drawn_pick.pick_number),
+                team_id: ActiveValue::Set(drawn_pick.team_id),
+                balls_held: ActiveValue::Set(drawn_pick.balls_held),
+                created_at: ActiveValue::NotSet,
+                updated_at: ActiveValue::NotSet,
+            });
+
+    rookie_draft_lottery_pick::Entity::insert_many(picks_to_insert)
+        .exec(db)
+        .await?;
+
+    rookie_draft_lottery::Entity::update_many()
+        .col_expr(
+            rookie_draft_lottery::Column::RngLog,
+            sea_orm::sea_query::Expr::value(rng_log),
+        )
+        .filter(rookie_draft_lottery::Column::Id.eq(rookie_draft_lottery_id))
+        .exec(db)
+        .await?;
+
+    Ok(())
+}

--- a/entity/src/queries/rookie_draft_selection_queries.rs
+++ b/entity/src/queries/rookie_draft_selection_queries.rs
@@ -1,6 +1,6 @@
-use std::fmt::Debug;
+use std::{collections::HashMap, fmt::Debug};
 
-use color_eyre::eyre::Result;
+use color_eyre::eyre::{Result, eyre};
 use sea_orm::{
     ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, EntityTrait, JoinType,
     QueryFilter, QueryOrder, QuerySelect, RelationTrait,
@@ -8,8 +8,11 @@ use sea_orm::{
 use tracing::instrument;
 
 use crate::{
-    contract, draft_pick,
+    contract,
+    deadline::{self, DeadlineKind},
+    deadline_queries, draft_pick,
     rookie_draft_selection::{self, RookieDraftSelectionStatus},
+    transaction::{self, TransactionKind},
 };
 
 /// Rookie draft selections made in a league's season, in draft order. The season comes from the
@@ -37,6 +40,135 @@ where
     Ok(selections)
 }
 
+/// The full ordered slate for the season's draft — the board.
+pub use find_rookie_draft_selections_for_league_season as get_selections_for_draft;
+
+/// The selection that is on the clock: the lowest-`order` `Unused` row. `None` once every pick is
+/// used or skipped.
+#[instrument]
+pub async fn get_on_the_clock_selection<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    db: &C,
+) -> Result<Option<rookie_draft_selection::Model>>
+where
+    C: ConnectionTrait + Debug,
+{
+    let selection = rookie_draft_selection::Entity::find()
+        .join(
+            JoinType::InnerJoin,
+            rookie_draft_selection::Relation::DraftPick.def(),
+        )
+        .filter(rookie_draft_selection::Column::LeagueId.eq(league_id))
+        .filter(draft_pick::Column::EndOfSeasonYear.eq(end_of_season_year))
+        .filter(rookie_draft_selection::Column::Status.eq(RookieDraftSelectionStatus::Unused))
+        .order_by_asc(rookie_draft_selection::Column::Order)
+        .one(db)
+        .await?;
+
+    Ok(selection)
+}
+
+/// Pre-creates the season's whole ordered slate as `Unused` rows, so the UI can show who is on the
+/// clock before any pick is made (the importer instead back-fills `order` per imported pick).
+///
+/// No-op if the slate already exists, which is what makes `start_rookie_draft` safe to call twice.
+#[instrument(skip(ordered_draft_pick_ids))]
+pub async fn build_draft_slate<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    ordered_draft_pick_ids: Vec<i64>,
+    db: &C,
+) -> Result<()>
+where
+    C: ConnectionTrait + Debug,
+{
+    if ordered_draft_pick_ids.is_empty()
+        || !get_selections_for_draft(league_id, end_of_season_year, db)
+            .await?
+            .is_empty()
+    {
+        return Ok(());
+    }
+
+    let owner_team_id_by_draft_pick_id: HashMap<i64, i64> = draft_pick::Entity::find()
+        .filter(draft_pick::Column::Id.is_in(ordered_draft_pick_ids.clone()))
+        .all(db)
+        .await?
+        .into_iter()
+        .map(|draft_pick_model| (draft_pick_model.id, draft_pick_model.current_owner_team_id))
+        .collect();
+
+    let mut models_to_insert = Vec::with_capacity(ordered_draft_pick_ids.len());
+    for (index, draft_pick_id) in ordered_draft_pick_ids.into_iter().enumerate() {
+        let current_owner_team_id = *owner_team_id_by_draft_pick_id
+            .get(&draft_pick_id)
+            .ok_or_else(|| eyre!("Could not find draft pick ({draft_pick_id}) for draft slate."))?;
+        let order = i16::try_from(index + 1)?;
+        models_to_insert.push(rookie_draft_selection::ActiveModel {
+            order: ActiveValue::Set(order),
+            status: ActiveValue::Set(RookieDraftSelectionStatus::Unused),
+            draft_pick_id: ActiveValue::Set(draft_pick_id),
+            league_id: ActiveValue::Set(league_id),
+            current_owner_team_id: ActiveValue::Set(current_owner_team_id),
+            ..Default::default()
+        });
+    }
+
+    rookie_draft_selection::Entity::insert_many(models_to_insert)
+        .exec(db)
+        .await?;
+
+    Ok(())
+}
+
+/// Contracts dropped while the draft was running, for the §7.3.4 re-draft ban.
+///
+/// The draft window is the `PreseasonRookieDraftStart` deadline through the following
+/// `PreseasonFinalRosterLock`, both inclusive — §7.3.3 allows drops in that window, §7.3.4 bans
+/// re-drafting those players.
+#[instrument]
+pub async fn find_players_dropped_during_draft<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    db: &C,
+) -> Result<Vec<contract::Model>>
+where
+    C: ConnectionTrait + Debug,
+{
+    let draft_start_deadline = deadline_queries::find_deadline_for_season_by_type(
+        league_id,
+        end_of_season_year,
+        DeadlineKind::PreseasonRookieDraftStart,
+        db,
+    )
+    .await?;
+    let roster_lock_deadline = deadline_queries::find_deadline_for_season_by_type(
+        league_id,
+        end_of_season_year,
+        DeadlineKind::PreseasonFinalRosterLock,
+        db,
+    )
+    .await?;
+
+    let dropped_contracts = contract::Entity::find()
+        .join(
+            JoinType::InnerJoin,
+            contract::Relation::DroppedContractTransaction.def(),
+        )
+        .join(JoinType::InnerJoin, transaction::Relation::Deadline.def())
+        .filter(contract::Column::LeagueId.eq(league_id))
+        .filter(transaction::Column::Kind.eq(TransactionKind::TeamUpdateDropContract))
+        .filter(deadline::Column::DateTime.between(
+            draft_start_deadline.date_time,
+            roster_lock_deadline.date_time,
+        ))
+        .all(db)
+        .await?;
+
+    Ok(dropped_contracts)
+}
+
 #[instrument]
 pub async fn insert_used_rookie_draft_selection<C>(
     signed_rookie_contract: &contract::Model,
@@ -51,6 +183,7 @@ where
         signed_rookie_contract.league_id,
         signed_rookie_contract.id,
         draft_pick_id,
+        current_owner_team_id_for_draft_pick(draft_pick_id, db).await?,
         overall_draft_rank,
     );
     let inserted_rookie_draft_selection = rookie_draft_selection_to_insert.insert(db).await?;
@@ -73,8 +206,25 @@ where
         contract_id: ActiveValue::NotSet,
         draft_pick_id: ActiveValue::Set(draft_pick_id),
         league_id: ActiveValue::Set(league_id),
+        current_owner_team_id: ActiveValue::Set(
+            current_owner_team_id_for_draft_pick(draft_pick_id, db).await?,
+        ),
         ..Default::default()
     };
     let inserted_rookie_draft_selection = rookie_draft_selection_to_insert.insert(db).await?;
     Ok(inserted_rookie_draft_selection)
+}
+
+/// Keeps the lazily-inserted (importer) paths filling the denormalized owner column without
+/// needing the caller to hand over a draft pick model.
+#[instrument]
+async fn current_owner_team_id_for_draft_pick<C>(draft_pick_id: i64, db: &C) -> Result<i64>
+where
+    C: ConnectionTrait + Debug,
+{
+    let draft_pick_model = draft_pick::Entity::find_by_id(draft_pick_id)
+        .one(db)
+        .await?
+        .ok_or_else(|| eyre!("Could not find draft pick ({draft_pick_id})."))?;
+    Ok(draft_pick_model.current_owner_team_id)
 }

--- a/entity/src/queries/rookie_draft_selection_queries.rs
+++ b/entity/src/queries/rookie_draft_selection_queries.rs
@@ -69,6 +69,41 @@ where
     Ok(selection)
 }
 
+/// A slate row by id, row-locked so two clients cannot resolve the same pick. Only meaningful
+/// inside a db transaction.
+#[instrument]
+pub async fn find_selection_by_id_for_update<C>(
+    selection_id: i64,
+    db: &C,
+) -> Result<rookie_draft_selection::Model>
+where
+    C: ConnectionTrait + Debug,
+{
+    rookie_draft_selection::Entity::find_by_id(selection_id)
+        .lock_exclusive()
+        .one(db)
+        .await?
+        .ok_or_else(|| eyre!("Could not find rookie draft selection ({selection_id})."))
+}
+
+/// Resolves a pre-created slate row to its outcome — the live-draft counterpart of
+/// [`insert_used_rookie_draft_selection`], which the importer needs only because it has no slate.
+#[instrument]
+pub async fn record_selection_result<C>(
+    selection_model: rookie_draft_selection::Model,
+    status: RookieDraftSelectionStatus,
+    maybe_contract_id: Option<i64>,
+    db: &C,
+) -> Result<rookie_draft_selection::Model>
+where
+    C: ConnectionTrait + Debug,
+{
+    let mut selection_to_update: rookie_draft_selection::ActiveModel = selection_model.into();
+    selection_to_update.status = ActiveValue::Set(status);
+    selection_to_update.contract_id = ActiveValue::Set(maybe_contract_id);
+    Ok(selection_to_update.update(db).await?)
+}
+
 /// Pre-creates the season's whole ordered slate as `Unused` rows, so the UI can show who is on the
 /// clock before any pick is made (the importer instead back-fills `order` per imported pick).
 ///

--- a/logic/CLAUDE.md
+++ b/logic/CLAUDE.md
@@ -24,6 +24,7 @@ values from there; do not duplicate literals into logic.
 | `eligibility/` | Classify players (auction vs rookie draft vs ineligible) and build the acquisition pools. |
 | `drop_contract/` | Drop a contract from a team; record dropped-contract cap penalty data. |
 | `ir/` | Move a contract to / activate from IR. |
+| `rookie_draft/` | Live rookie draft: order from standings + lottery, make/pass picks, re-draft ban. |
 | `rookie_development_activation/` | Activate an RD/RDI contract into a rookie contract. |
 | `rookie_development_international/` | Move contracts RD↔RDI (stateside ↔ international). |
 | `roster/` | Salary + cap calculation (incl. dropped-contract penalties). |

--- a/logic/Cargo.toml
+++ b/logic/Cargo.toml
@@ -12,6 +12,7 @@ fbkl-constants = {path = "../constants"}
 fbkl-entity = {path = "../entity"}
 multimap = "0.9.0"
 once_cell = "1.18.0"
+rand = "0.8.5"
 thiserror = "2.0.12"
 tracing = "0.1.36"
 

--- a/logic/src/lib.rs
+++ b/logic/src/lib.rs
@@ -7,6 +7,7 @@ pub mod eligibility;
 pub mod ir;
 pub mod rookie_development_activation;
 pub mod rookie_development_international;
+pub mod rookie_draft;
 pub mod roster;
 pub mod team_ownership;
 pub mod trade;

--- a/logic/src/rookie_draft/draft_order.rs
+++ b/logic/src/rookie_draft/draft_order.rs
@@ -1,0 +1,304 @@
+//! Rookie draft order computation (§7.2.1).
+//!
+//! The order is derived from the frozen `league_team_season_standing` inputs plus the lottery
+//! result: round 1 is the six drawn lottery slots followed by the playoff teams worst-finish first
+//! (champion picks last), and rounds 2–5 repeat one identical order — non-playoff teams in reverse
+//! mid-season rank, then playoff teams best-finish first. This is not a snake draft.
+//!
+//! Each ordered slot belongs to a team's *natural* pick (`original_owner_team_id`) but is made by
+//! whoever holds it now (`current_owner_team_id`), so traded picks land with the acquirer.
+
+use std::{cmp::Reverse, collections::HashMap};
+
+use color_eyre::{
+    Result,
+    eyre::{bail, ensure, eyre},
+};
+use fbkl_constants::league_rules::DRAFT_PICK_ROUNDS;
+use fbkl_entity::{draft_pick, league_team_season_standing};
+
+/// One slot of the ordered draft slate, in overall pick order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DraftSlot {
+    pub round: i16,
+    pub draft_pick_id: i64,
+    pub current_owner_team_id: i64,
+}
+
+/// Returns every draft slot for the season in overall pick order (§7.2.1).
+///
+/// `lottery_team_order` is the drawn order of the non-playoff teams from
+/// [`super::run_lottery`], which fills round 1's first slots.
+pub fn compute_draft_order(
+    standings: &[league_team_season_standing::Model],
+    lottery_team_order: &[i64],
+    draft_picks: &[draft_pick::Model],
+) -> Result<Vec<DraftSlot>> {
+    let (playoff_standings, non_playoff_standings): (Vec<_>, Vec<_>) = standings
+        .iter()
+        .partition(|standing| standing.made_playoffs);
+
+    ensure!(
+        lottery_team_order.len() == non_playoff_standings.len(),
+        "lottery drew {} teams but {} teams missed the playoffs.",
+        lottery_team_order.len(),
+        non_playoff_standings.len()
+    );
+    for team_id in lottery_team_order {
+        ensure!(
+            non_playoff_standings
+                .iter()
+                .any(|standing| standing.team_id == *team_id),
+            "lottery team ({team_id}) did not miss the playoffs."
+        );
+    }
+
+    // (playoff_finish, regular_season_rank, team_id) — the §7.2.1 keys, team_id breaking any tie.
+    let mut playoff_seeds = playoff_standings
+        .iter()
+        .map(|standing| {
+            let playoff_finish = standing.playoff_finish.ok_or_else(|| {
+                eyre!(
+                    "playoff team ({}) has no playoff_finish recorded.",
+                    standing.team_id
+                )
+            })?;
+            Ok((
+                playoff_finish,
+                standing.regular_season_rank,
+                standing.team_id,
+            ))
+        })
+        .collect::<Result<Vec<_>>>()?;
+
+    // Round 1: worst playoff finish drafts first, champion last; ties go to the worse record.
+    playoff_seeds.sort_by_key(|&(playoff_finish, regular_season_rank, team_id)| {
+        (
+            Reverse(playoff_finish),
+            Reverse(regular_season_rank),
+            team_id,
+        )
+    });
+    let round_one_teams: Vec<i64> = lottery_team_order
+        .iter()
+        .copied()
+        .chain(playoff_seeds.iter().map(|&(_, _, team_id)| team_id))
+        .collect();
+
+    // Rounds 2–5: reverse of round 1's playoff block, so the best finish drafts first there.
+    playoff_seeds.sort_by_key(|&(playoff_finish, regular_season_rank, team_id)| {
+        (playoff_finish, regular_season_rank, team_id)
+    });
+    let mut non_playoff_seeds: Vec<_> = non_playoff_standings
+        .iter()
+        .map(|standing| {
+            (
+                standing.mid_season_rank,
+                standing.regular_season_rank,
+                standing.team_id,
+            )
+        })
+        .collect();
+    non_playoff_seeds.sort_by_key(|&(mid_season_rank, regular_season_rank, team_id)| {
+        (
+            Reverse(mid_season_rank),
+            Reverse(regular_season_rank),
+            team_id,
+        )
+    });
+    let later_round_teams: Vec<i64> = non_playoff_seeds
+        .iter()
+        .chain(playoff_seeds.iter())
+        .map(|&(_, _, team_id)| team_id)
+        .collect();
+
+    let picks_by_natural_slot = index_picks_by_natural_slot(draft_picks);
+
+    let mut slots = Vec::with_capacity(round_one_teams.len() * usize::try_from(DRAFT_PICK_ROUNDS)?);
+    for round in 1..=DRAFT_PICK_ROUNDS {
+        let round_teams = if round == 1 {
+            &round_one_teams
+        } else {
+            &later_round_teams
+        };
+
+        for &team_id in round_teams {
+            let Some(draft_pick_model) = picks_by_natural_slot.get(&(round, team_id)) else {
+                bail!("no round {round} draft pick found for team ({team_id}).");
+            };
+            slots.push(DraftSlot {
+                round,
+                draft_pick_id: draft_pick_model.id,
+                current_owner_team_id: draft_pick_model.current_owner_team_id,
+            });
+        }
+    }
+
+    Ok(slots)
+}
+
+/// Indexes picks by the (round, original owner) slot the draft order is built from.
+fn index_picks_by_natural_slot(
+    draft_picks: &[draft_pick::Model],
+) -> HashMap<(i16, i64), &draft_pick::Model> {
+    let mut sorted_picks: Vec<&draft_pick::Model> = draft_picks.iter().collect();
+    sorted_picks.sort_by_key(|draft_pick_model| draft_pick_model.id);
+
+    let mut picks_by_natural_slot = HashMap::with_capacity(sorted_picks.len());
+    for draft_pick_model in sorted_picks {
+        picks_by_natural_slot
+            .entry((
+                draft_pick_model.round,
+                draft_pick_model.original_owner_team_id,
+            ))
+            .or_insert(draft_pick_model);
+    }
+    picks_by_natural_slot
+}
+
+#[cfg(test)]
+mod tests {
+    use fbkl_constants::league_rules::DRAFT_PICK_ROUNDS;
+    use fbkl_entity::{draft_pick, league_team_season_standing};
+
+    use super::compute_draft_order;
+
+    const END_OF_SEASON_YEAR: i16 = 2025;
+
+    fn standing(
+        team_id: i64,
+        regular_season_rank: i16,
+        mid_season_rank: i16,
+        playoff_finish: Option<i16>,
+    ) -> league_team_season_standing::Model {
+        league_team_season_standing::Model {
+            id: team_id,
+            league_id: 1,
+            team_id,
+            end_of_season_year: END_OF_SEASON_YEAR,
+            regular_season_rank,
+            mid_season_rank,
+            made_playoffs: playoff_finish.is_some(),
+            playoff_finish,
+            created_at: chrono::Utc::now().into(),
+            updated_at: chrono::Utc::now().into(),
+        }
+    }
+
+    /// 12 teams: 1–6 made the playoffs (finish 1..=6), 7–12 did not.
+    fn standings() -> Vec<league_team_season_standing::Model> {
+        (1..=12)
+            .map(|team_id| {
+                let rank = i16::try_from(team_id).unwrap();
+                let playoff_finish = (team_id <= 6).then_some(rank);
+                standing(team_id, rank, rank, playoff_finish)
+            })
+            .collect()
+    }
+
+    /// One pick per team per round, each still held by its original owner.
+    fn draft_picks() -> Vec<draft_pick::Model> {
+        (1..=DRAFT_PICK_ROUNDS)
+            .flat_map(|round| {
+                (1..=12).map(move |team_id| draft_pick::Model {
+                    id: i64::from(round) * 100 + team_id,
+                    round,
+                    end_of_season_year: END_OF_SEASON_YEAR,
+                    league_id: 1,
+                    current_owner_team_id: team_id,
+                    original_owner_team_id: team_id,
+                    created_at: chrono::Utc::now().into(),
+                    updated_at: chrono::Utc::now().into(),
+                })
+            })
+            .collect()
+    }
+
+    fn lottery_order() -> Vec<i64> {
+        vec![9, 12, 7, 11, 8, 10]
+    }
+
+    fn owners_for_round(slots: &[super::DraftSlot], round: i16) -> Vec<i64> {
+        slots
+            .iter()
+            .filter(|slot| slot.round == round)
+            .map(|slot| slot.current_owner_team_id)
+            .collect()
+    }
+
+    #[test]
+    fn round_one_follows_lottery_then_playoff_finish() {
+        let slots = compute_draft_order(&standings(), &lottery_order(), &draft_picks()).unwrap();
+
+        assert_eq!(
+            slots.len(),
+            12 * usize::try_from(DRAFT_PICK_ROUNDS).unwrap()
+        );
+        // Lottery order, then worst playoff finish (6) down to the champion (1) last.
+        assert_eq!(
+            owners_for_round(&slots, 1),
+            vec![9, 12, 7, 11, 8, 10, 6, 5, 4, 3, 2, 1]
+        );
+    }
+
+    #[test]
+    fn later_rounds_share_one_order_worst_mid_season_rank_first() {
+        let slots = compute_draft_order(&standings(), &lottery_order(), &draft_picks()).unwrap();
+
+        // Non-playoff teams worst mid-season rank first, then playoff teams best finish first.
+        let expected = vec![12, 11, 10, 9, 8, 7, 1, 2, 3, 4, 5, 6];
+        for round in 2..=DRAFT_PICK_ROUNDS {
+            assert_eq!(owners_for_round(&slots, round), expected);
+        }
+    }
+
+    #[test]
+    fn traded_pick_lands_with_its_current_owner() {
+        let mut picks = draft_picks();
+        let traded_pick = picks
+            .iter_mut()
+            .find(|pick| pick.round == 1 && pick.original_owner_team_id == 9)
+            .unwrap();
+        traded_pick.current_owner_team_id = 3;
+
+        let slots = compute_draft_order(&standings(), &lottery_order(), &picks).unwrap();
+
+        // Team 9 won the lottery, so its slot stays first — but team 3 makes the pick.
+        assert_eq!(slots[0].current_owner_team_id, 3);
+    }
+
+    #[test]
+    fn tied_mid_season_ranks_break_by_record_then_team_id() {
+        let mut standings = standings();
+        for standing in &mut standings {
+            // Teams 7/8/9 all tie at mid-season rank 7; their records differ, 11 and 12 do not.
+            match standing.team_id {
+                7..=9 => standing.mid_season_rank = 7,
+                11..=12 => {
+                    standing.mid_season_rank = 11;
+                    standing.regular_season_rank = 11;
+                }
+                _ => {}
+            }
+        }
+
+        let slots = compute_draft_order(&standings, &lottery_order(), &draft_picks()).unwrap();
+
+        // Worse record drafts first within a tie; team_id breaks a full tie (11 before 12).
+        assert_eq!(
+            owners_for_round(&slots, 2)[..6].to_vec(),
+            vec![11, 12, 10, 9, 8, 7]
+        );
+    }
+
+    #[test]
+    fn rejects_a_lottery_order_that_does_not_match_the_non_playoff_teams() {
+        let short_lottery = vec![9, 12, 7];
+        assert!(compute_draft_order(&standings(), &short_lottery, &draft_picks()).is_err());
+
+        let playoff_team_in_lottery = vec![1, 12, 7, 11, 8, 10];
+        assert!(
+            compute_draft_order(&standings(), &playoff_team_in_lottery, &draft_picks()).is_err()
+        );
+    }
+}

--- a/logic/src/rookie_draft/lottery.rs
+++ b/logic/src/rookie_draft/lottery.rs
@@ -1,0 +1,206 @@
+//! The rookie draft lottery for first-round picks 1-6 (§7.2.4-§7.2.5).
+//!
+//! The six non-playoff teams get 6/5/4/3/2/1 balls by mid-season rank (worst gets the most) and
+//! picks 1 through 6 are drawn sequentially, each winner leaving the pool before the next draw.
+//! Balls belong to the *standings slot*, so a non-playoff team that traded its first-rounder away
+//! still supplies the odds — the resulting pick just lands with the current owner.
+//!
+//! The draw is a seeded `StdRng`, and the seed is committed to the database before the draw is
+//! revealed, so any owner can re-run it and confirm the order was not re-rolled.
+
+use std::{cmp::Reverse, fmt::Write as _};
+
+use color_eyre::{Result, eyre::ensure};
+use fbkl_constants::league_rules::ROOKIE_DRAFT_LOTTERY_BALLS;
+use fbkl_entity::{
+    league_team_season_standing,
+    rookie_draft_lottery_queries::{self, NewRookieDraftLotteryPick},
+    sea_orm::ConnectionTrait,
+};
+use rand::{Rng, SeedableRng, rngs::StdRng};
+use tracing::instrument;
+
+/// Runs (or replays) the league season's lottery, returning the drawn non-playoff team ids in
+/// pick order.
+///
+/// Already-run lotteries are replayed from the stored draw rather than re-rolled, so a second call
+/// from the scheduler or a commissioner cannot change the order.
+#[instrument(skip(standings))]
+pub async fn run_lottery<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    standings: &[league_team_season_standing::Model],
+    db: &C,
+) -> Result<Vec<i64>>
+where
+    C: ConnectionTrait + std::fmt::Debug,
+{
+    if let Some(existing_lottery) = rookie_draft_lottery_queries::find_lottery_for_league_season(
+        league_id,
+        end_of_season_year,
+        db,
+    )
+    .await?
+    {
+        let existing_picks =
+            rookie_draft_lottery_queries::find_lottery_picks(existing_lottery.id, db).await?;
+        if !existing_picks.is_empty() {
+            return Ok(existing_picks
+                .into_iter()
+                .map(|pick| pick.team_id)
+                .collect());
+        }
+    }
+
+    let seed = rand::random::<i64>();
+    let lottery_model =
+        rookie_draft_lottery_queries::insert_lottery_seed(league_id, end_of_season_year, seed, db)
+            .await?;
+
+    // The committed seed wins: a crash between commit and reveal replays the same draw.
+    let (drawn_picks, rng_log) = draw_lottery(standings, lottery_model.rng_seed)?;
+    let team_order = drawn_picks.iter().map(|pick| pick.team_id).collect();
+    rookie_draft_lottery_queries::save_lottery_draw(lottery_model.id, drawn_picks, rng_log, db)
+        .await?;
+
+    Ok(team_order)
+}
+
+/// Draws picks 1-6 from the seeded ball pool, returning the drawn slots and the audit log.
+fn draw_lottery(
+    standings: &[league_team_season_standing::Model],
+    seed: i64,
+) -> Result<(Vec<NewRookieDraftLotteryPick>, String)> {
+    // Worst mid-season rank first, ties by worse record then team_id, matching `compute_draft_order`.
+    let mut non_playoff_standings: Vec<_> = standings
+        .iter()
+        .filter(|standing| !standing.made_playoffs)
+        .collect();
+    non_playoff_standings.sort_by_key(|standing| {
+        (
+            Reverse(standing.mid_season_rank),
+            Reverse(standing.regular_season_rank),
+            standing.team_id,
+        )
+    });
+    ensure!(
+        non_playoff_standings.len() == ROOKIE_DRAFT_LOTTERY_BALLS.len(),
+        "the lottery needs {} non-playoff teams but the standings have {}.",
+        ROOKIE_DRAFT_LOTTERY_BALLS.len(),
+        non_playoff_standings.len()
+    );
+
+    let mut pool: Vec<(i64, u32)> = non_playoff_standings
+        .iter()
+        .zip(ROOKIE_DRAFT_LOTTERY_BALLS)
+        .map(|(standing, balls)| (standing.team_id, balls))
+        .collect();
+
+    let mut rng = StdRng::seed_from_u64(seed.cast_unsigned());
+    let mut drawn_picks = Vec::with_capacity(pool.len());
+    let mut rng_log = format!("seed={seed}\n");
+
+    for pick_number in 1..=i16::try_from(ROOKIE_DRAFT_LOTTERY_BALLS.len())? {
+        let total_balls: u32 = pool.iter().map(|&(_, balls)| balls).sum();
+        let mut drawn_ball = rng.gen_range(0..total_balls);
+        // The drawn ball is below the pool total, so it always lands inside one team's ball range.
+        let mut winning_index = pool.len() - 1;
+        for (index, &(_, balls)) in pool.iter().enumerate() {
+            if drawn_ball < balls {
+                winning_index = index;
+                break;
+            }
+            drawn_ball -= balls;
+        }
+        let (team_id, balls_held) = pool.remove(winning_index);
+
+        writeln!(
+            rng_log,
+            "pick {pick_number}: team {team_id} ({balls_held}/{total_balls} balls)"
+        )?;
+        drawn_picks.push(NewRookieDraftLotteryPick {
+            pick_number,
+            team_id,
+            balls_held: i16::try_from(balls_held)?,
+        });
+    }
+
+    Ok((drawn_picks, rng_log))
+}
+
+#[cfg(test)]
+mod tests {
+    use fbkl_entity::league_team_season_standing;
+
+    use super::draw_lottery;
+
+    /// 12 teams: 1-6 made the playoffs, 7-12 did not (12 is the worst, so it holds 6 balls).
+    fn standings() -> Vec<league_team_season_standing::Model> {
+        (1..=12)
+            .map(|team_id| {
+                let rank = i16::try_from(team_id).unwrap();
+                league_team_season_standing::Model {
+                    id: team_id,
+                    league_id: 1,
+                    team_id,
+                    end_of_season_year: 2025,
+                    regular_season_rank: rank,
+                    mid_season_rank: rank,
+                    made_playoffs: team_id <= 6,
+                    playoff_finish: (team_id <= 6).then_some(rank),
+                    created_at: chrono::Utc::now().into(),
+                    updated_at: chrono::Utc::now().into(),
+                }
+            })
+            .collect()
+    }
+
+    #[test]
+    fn draw_is_reproducible_for_a_seed() {
+        let (first_draw, first_log) = draw_lottery(&standings(), 42).unwrap();
+        let (second_draw, second_log) = draw_lottery(&standings(), 42).unwrap();
+
+        let team_order: Vec<i64> = first_draw.iter().map(|pick| pick.team_id).collect();
+        assert_eq!(team_order.len(), 6);
+        assert_eq!(
+            team_order,
+            second_draw
+                .iter()
+                .map(|pick| pick.team_id)
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(first_log, second_log);
+        // Every non-playoff team is drawn exactly once, worst team holding 6 balls.
+        let mut sorted_teams = team_order;
+        sorted_teams.sort_unstable();
+        assert_eq!(sorted_teams, vec![7, 8, 9, 10, 11, 12]);
+        assert_eq!(
+            first_draw
+                .iter()
+                .find(|pick| pick.team_id == 12)
+                .unwrap()
+                .balls_held,
+            6
+        );
+    }
+
+    #[test]
+    fn ball_weighting_favours_the_worst_team() {
+        let standings = standings();
+        let mut first_pick_wins = [0_u32; 13];
+        for seed in 0..600 {
+            let (draw, _) = draw_lottery(&standings, seed).unwrap();
+            first_pick_wins[usize::try_from(draw[0].team_id).unwrap()] += 1;
+        }
+
+        // 6 balls vs 1: the worst team should win pick 1 far more often than the best non-playoff team.
+        assert!(first_pick_wins[12] > first_pick_wins[7] * 2);
+    }
+
+    #[test]
+    fn rejects_standings_without_six_non_playoff_teams() {
+        let mut standings = standings();
+        standings.retain(|standing| standing.team_id != 12);
+        assert!(draw_lottery(&standings, 1).is_err());
+    }
+}

--- a/logic/src/rookie_draft/make_pick.rs
+++ b/logic/src/rookie_draft/make_pick.rs
@@ -1,0 +1,383 @@
+//! Making a rookie-draft pick (§7.3) — the live counterpart of what `import-data` replays from CSV.
+//!
+//! Produces exactly the rows `seasonal_rookie_selection_transactions::process_rookie_selected`
+//! produces (RD contract + `RookieDraftSelection` transaction + `AddViaRookieDraft` update),
+//! but validates first: on the clock, in the eligible pool, not re-draft banned, roster room.
+
+use std::{collections::HashSet, fmt::Debug};
+
+use chrono::NaiveDate;
+use color_eyre::{Result, eyre::eyre};
+use fbkl_constants::league_rules::{
+    PRE_SEASON_CONTRACTS_PER_ROSTER_LIMIT, rookie_draft_salary_for_round,
+};
+use fbkl_entity::{
+    contract::{self, RelatedPlayer},
+    contract_queries,
+    deadline::DeadlineKind,
+    deadline_queries, draft_pick_queries,
+    rookie_draft_selection::{self, RookieDraftSelectionStatus},
+    rookie_draft_selection_queries,
+    sea_orm::{ActiveValue, ConnectionTrait, TransactionTrait},
+    team_update::{
+        self, ContractUpdate, ContractUpdateType, TeamUpdateAsset, TeamUpdateData, TeamUpdateStatus,
+    },
+    team_update_queries::{self, ContractUpdatePlayerData},
+    transaction_queries,
+};
+use tracing::instrument;
+
+use crate::{
+    eligibility::build_rookie_draft_eligible_pool,
+    roster::{SalarySnapshot, calculate_team_contract_salary},
+};
+
+/// Why a pick was refused. Each variant maps to a distinct user-facing error code.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum PickRejection {
+    #[error("The draft has not started for this league season.")]
+    DraftNotStarted,
+    #[error("Selection {selection_id} is not on the clock (pick {on_the_clock_order} is).")]
+    NotOnTheClock {
+        selection_id: i64,
+        on_the_clock_order: i16,
+    },
+    #[error("Selection {selection_id} has already been used or passed.")]
+    SelectionAlreadyResolved { selection_id: i64 },
+    #[error("Player is not in the rookie draft eligible pool (§7.5).")]
+    PlayerNotEligible,
+    #[error("Player was dropped during this draft and cannot be re-drafted (§7.3.4).")]
+    ReDraftBanned,
+    #[error("Team rosters {roster_used} contracts already, and the limit is {roster_limit}.")]
+    NoRosterSpace {
+        roster_used: usize,
+        roster_limit: i16,
+    },
+}
+
+/// The §7.3.4 re-draft ban set: players dropped during this draft, keyed the way a contract keys a
+/// player (real NBA player or league-created one).
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct ReDraftBan {
+    players: HashSet<i64>,
+    league_players: HashSet<i64>,
+}
+
+impl ReDraftBan {
+    pub fn is_banned(&self, player_id: i64, is_league_player: bool) -> bool {
+        if is_league_player {
+            self.league_players.contains(&player_id)
+        } else {
+            self.players.contains(&player_id)
+        }
+    }
+
+    fn from_dropped_contracts(dropped_contracts: &[contract::Model]) -> Self {
+        let mut ban = Self::default();
+        for dropped_contract in dropped_contracts {
+            if let Some(player_id) = dropped_contract.player_id {
+                ban.players.insert(player_id);
+            }
+            if let Some(league_player_id) = dropped_contract.league_player_id {
+                ban.league_players.insert(league_player_id);
+            }
+        }
+        ban
+    }
+}
+
+/// The set of players banned from being (re-)drafted in this draft (§7.3.4).
+///
+/// Exposed on its own so the eligible-pool query can grey banned players out with a reason instead
+/// of only failing at pick time.
+#[instrument(skip(db))]
+pub async fn re_draft_ban_check<C>(
+    league_id: i64,
+    end_of_season_year: i16,
+    db: &C,
+) -> Result<ReDraftBan>
+where
+    C: ConnectionTrait + Debug,
+{
+    let dropped_contracts = rookie_draft_selection_queries::find_players_dropped_during_draft(
+        league_id,
+        end_of_season_year,
+        db,
+    )
+    .await?;
+    Ok(ReDraftBan::from_dropped_contracts(&dropped_contracts))
+}
+
+/// Drafts a player with the on-the-clock selection (§7.3).
+///
+/// `is_league_player` picks which id space `player_id` lives in, matching
+/// `contract::Model::new_contract_from_rookie_draft`.
+#[instrument(skip(db))]
+pub async fn make_pick<C>(
+    selection_id: i64,
+    player_id: i64,
+    is_league_player: bool,
+    db: &C,
+) -> Result<rookie_draft_selection::Model>
+where
+    C: ConnectionTrait + TransactionTrait + Debug,
+{
+    let db_txn = db.begin().await?;
+
+    // Locking the slate row first is what serializes two clients racing the same pick.
+    let selection_model =
+        rookie_draft_selection_queries::find_selection_by_id_for_update(selection_id, &db_txn)
+            .await?;
+    if selection_model.status != RookieDraftSelectionStatus::Unused {
+        return Err(PickRejection::SelectionAlreadyResolved { selection_id }.into());
+    }
+
+    let draft_pick_model =
+        draft_pick_queries::find_draft_pick_by_id(selection_model.draft_pick_id, &db_txn).await?;
+    let league_id = selection_model.league_id;
+    let end_of_season_year = draft_pick_model.end_of_season_year;
+
+    assert_on_the_clock(&selection_model, end_of_season_year, &db_txn).await?;
+
+    let eligible_pool =
+        build_rookie_draft_eligible_pool(league_id, end_of_season_year, &db_txn).await?;
+    if !pool_contains(&eligible_pool, player_id, is_league_player) {
+        return Err(PickRejection::PlayerNotEligible.into());
+    }
+
+    if re_draft_ban_check(league_id, end_of_season_year, &db_txn)
+        .await?
+        .is_banned(player_id, is_league_player)
+    {
+        return Err(PickRejection::ReDraftBanned.into());
+    }
+
+    // §7.3.2 wants roster room, not cap (RD is off-cap); preseason draft = the 32-contract limit.
+    let drafting_team_id = selection_model.current_owner_team_id;
+    let active_contracts =
+        contract_queries::find_active_contracts_for_team(drafting_team_id, &db_txn).await?;
+    if active_contracts.len() >= usize::try_from(PRE_SEASON_CONTRACTS_PER_ROSTER_LIMIT)? {
+        return Err(PickRejection::NoRosterSpace {
+            roster_used: active_contracts.len(),
+            roster_limit: PRE_SEASON_CONTRACTS_PER_ROSTER_LIMIT,
+        }
+        .into());
+    }
+
+    let deadline_model = deadline_queries::find_deadline_for_season_by_type(
+        league_id,
+        end_of_season_year,
+        DeadlineKind::PreseasonRookieDraftStart,
+        &db_txn,
+    )
+    .await?;
+    let SalarySnapshot {
+        salary: previous_salary,
+        cap: previous_salary_cap,
+    } = calculate_team_contract_salary(
+        drafting_team_id,
+        &active_contracts,
+        &deadline_model,
+        &db_txn,
+    )
+    .await?;
+
+    let rookie_contract_model = contract_queries::create_new_contract(
+        contract::Model::new_contract_from_rookie_draft(
+            league_id,
+            end_of_season_year,
+            drafting_team_id,
+            rookie_draft_salary_for_round(draft_pick_model.round),
+            player_id,
+            is_league_player,
+        ),
+        &db_txn,
+    )
+    .await?;
+
+    let mut updated_selection_model = rookie_draft_selection_queries::record_selection_result(
+        selection_model,
+        RookieDraftSelectionStatus::PlayerSelected,
+        Some(rookie_contract_model.id),
+        &db_txn,
+    )
+    .await?;
+
+    let transaction_model = transaction_queries::insert_rookie_draft_selection_transaction(
+        &deadline_model,
+        updated_selection_model.id,
+        &db_txn,
+    )
+    .await?;
+    updated_selection_model.transaction_id = Some(transaction_model.id);
+
+    insert_team_update_for_pick(
+        &rookie_contract_model,
+        &active_contracts,
+        SalarySnapshot {
+            salary: previous_salary,
+            cap: previous_salary_cap,
+        },
+        deadline_model.date_time.date_naive(),
+        transaction_model.id,
+        &db_txn,
+    )
+    .await?;
+
+    db_txn.commit().await?;
+
+    Ok(updated_selection_model)
+}
+
+/// The `Done` `team_update` recording the drafted player joining the roster.
+#[instrument(skip(db))]
+async fn insert_team_update_for_pick<C>(
+    rookie_contract_model: &contract::Model,
+    active_contracts: &[contract::Model],
+    salary_snapshot: SalarySnapshot,
+    effective_date: NaiveDate,
+    transaction_id: i64,
+    db: &C,
+) -> Result<()>
+where
+    C: ConnectionTrait + Debug,
+{
+    let contract_update_player_data =
+        ContractUpdatePlayerData::from_contract_model(rookie_contract_model, db).await?;
+    let mut team_contract_ids: Vec<i64> = active_contracts
+        .iter()
+        .map(|contract_model| contract_model.id)
+        .collect();
+    team_contract_ids.push(rookie_contract_model.id);
+    let SalarySnapshot { salary, cap } = salary_snapshot;
+    // Salary is unchanged either side of the pick: RD contracts do not count against the cap.
+    let team_update_data = TeamUpdateData::from_assets(
+        team_contract_ids,
+        vec![TeamUpdateAsset::Contracts(vec![ContractUpdate {
+            contract_id: rookie_contract_model.id,
+            update_type: ContractUpdateType::AddViaRookieDraft,
+            player_name_at_time: contract_update_player_data.player_name,
+            player_team_abbr_at_time: contract_update_player_data.real_team_abbr,
+            player_team_name_at_time: contract_update_player_data.real_team_name,
+        }])],
+        salary,
+        cap,
+        salary,
+        cap,
+    );
+    team_update_queries::insert_team_update(
+        team_update::ActiveModel {
+            data: ActiveValue::Set(team_update_data.to_json()?),
+            effective_date: ActiveValue::Set(effective_date),
+            status: ActiveValue::Set(TeamUpdateStatus::Done),
+            team_id: ActiveValue::Set(
+                rookie_contract_model
+                    .team_id
+                    .ok_or_else(|| eyre!("Rookie draft contract has no team."))?,
+            ),
+            transaction_id: ActiveValue::Set(Some(transaction_id)),
+            ..Default::default()
+        },
+        db,
+    )
+    .await?;
+    Ok(())
+}
+
+/// Re-asserts inside the db transaction that this selection is still the lowest-`order` `Unused`
+/// row, so a pick cannot jump the queue.
+#[instrument(skip(db))]
+pub(super) async fn assert_on_the_clock<C>(
+    selection_model: &rookie_draft_selection::Model,
+    end_of_season_year: i16,
+    db: &C,
+) -> Result<()>
+where
+    C: ConnectionTrait + Debug,
+{
+    let maybe_on_the_clock = rookie_draft_selection_queries::get_on_the_clock_selection(
+        selection_model.league_id,
+        end_of_season_year,
+        db,
+    )
+    .await?;
+    let Some(on_the_clock) = maybe_on_the_clock else {
+        return Err(PickRejection::DraftNotStarted.into());
+    };
+    if on_the_clock.id != selection_model.id {
+        return Err(PickRejection::NotOnTheClock {
+            selection_id: selection_model.id,
+            on_the_clock_order: on_the_clock.order,
+        }
+        .into());
+    }
+    Ok(())
+}
+
+fn pool_contains(pool: &[RelatedPlayer], player_id: i64, is_league_player: bool) -> bool {
+    pool.iter().any(|related_player| match related_player {
+        RelatedPlayer::LeaguePlayer(league_player_model) => {
+            is_league_player && league_player_model.id == player_id
+        }
+        RelatedPlayer::Player(player_model) => !is_league_player && player_model.id == player_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use fbkl_constants::league_rules::rookie_draft_salary_for_round;
+    use fbkl_entity::contract::{self, ContractKind, ContractStatus};
+
+    use super::ReDraftBan;
+
+    fn dropped_contract(
+        maybe_player_id: Option<i64>,
+        maybe_league_player_id: Option<i64>,
+    ) -> contract::Model {
+        contract::Model {
+            id: 1,
+            year_number: 1,
+            kind: ContractKind::Veteran,
+            is_ir: false,
+            salary: 1,
+            end_of_season_year: 2026,
+            status: ContractStatus::Replaced,
+            league_id: 1,
+            league_player_id: maybe_league_player_id,
+            player_id: maybe_player_id,
+            previous_contract_id: None,
+            original_contract_id: None,
+            team_id: None,
+            created_at: chrono::Utc::now().into(),
+            updated_at: chrono::Utc::now().into(),
+        }
+    }
+
+    #[test]
+    fn re_draft_ban_covers_both_player_id_spaces() {
+        let ban = ReDraftBan::from_dropped_contracts(&[
+            dropped_contract(Some(10), None),
+            dropped_contract(None, Some(20)),
+        ]);
+
+        assert!(ban.is_banned(10, false));
+        assert!(ban.is_banned(20, true));
+        // Same number, wrong id space, must not collide.
+        assert!(!ban.is_banned(10, true));
+        assert!(!ban.is_banned(20, false));
+        assert!(!ban.is_banned(99, false));
+    }
+
+    #[test]
+    fn no_drops_bans_nobody() {
+        let ban = ReDraftBan::from_dropped_contracts(&[]);
+        assert!(!ban.is_banned(1, false));
+        assert!(!ban.is_banned(1, true));
+    }
+
+    #[test]
+    fn rd_salary_follows_the_pick_round() {
+        let salaries: Vec<i16> = (1..=5).map(rookie_draft_salary_for_round).collect();
+        assert_eq!(salaries, vec![4, 3, 2, 1, 1]);
+    }
+}

--- a/logic/src/rookie_draft/mod.rs
+++ b/logic/src/rookie_draft/mod.rs
@@ -1,5 +1,7 @@
 //! The live rookie draft (§7): draft order, lottery, and the make/pass pick flow.
 
 mod draft_order;
+mod lottery;
 
 pub use draft_order::{DraftSlot, compute_draft_order};
+pub use lottery::run_lottery;

--- a/logic/src/rookie_draft/mod.rs
+++ b/logic/src/rookie_draft/mod.rs
@@ -3,9 +3,11 @@
 mod draft_order;
 mod lottery;
 mod make_pick;
+mod pass_pick;
 mod start_draft;
 
 pub use draft_order::{DraftSlot, compute_draft_order};
 pub use lottery::run_lottery;
 pub use make_pick::{PickRejection, ReDraftBan, make_pick, re_draft_ban_check};
+pub use pass_pick::pass_pick;
 pub use start_draft::start_rookie_draft;

--- a/logic/src/rookie_draft/mod.rs
+++ b/logic/src/rookie_draft/mod.rs
@@ -2,8 +2,10 @@
 
 mod draft_order;
 mod lottery;
+mod make_pick;
 mod start_draft;
 
 pub use draft_order::{DraftSlot, compute_draft_order};
 pub use lottery::run_lottery;
+pub use make_pick::{PickRejection, ReDraftBan, make_pick, re_draft_ban_check};
 pub use start_draft::start_rookie_draft;

--- a/logic/src/rookie_draft/mod.rs
+++ b/logic/src/rookie_draft/mod.rs
@@ -1,0 +1,5 @@
+//! The live rookie draft (§7): draft order, lottery, and the make/pass pick flow.
+
+mod draft_order;
+
+pub use draft_order::{DraftSlot, compute_draft_order};

--- a/logic/src/rookie_draft/mod.rs
+++ b/logic/src/rookie_draft/mod.rs
@@ -2,6 +2,8 @@
 
 mod draft_order;
 mod lottery;
+mod start_draft;
 
 pub use draft_order::{DraftSlot, compute_draft_order};
 pub use lottery::run_lottery;
+pub use start_draft::start_rookie_draft;

--- a/logic/src/rookie_draft/pass_pick.rs
+++ b/logic/src/rookie_draft/pass_pick.rs
@@ -1,0 +1,75 @@
+//! Passing a rookie-draft pick (§7.3.1).
+//!
+//! Passing asks nothing of the owner — no roster room, no eligible player — so the only guards are
+//! that the row is still unresolved and still on the clock. Unlike every other state change this
+//! records a transaction and NO `team_update`: no asset changed hands.
+//!
+//! The passed row stays in the slate as `Skipped`, so it keeps consuming its `order` slot and the
+//! draft moves on to the next `Unused` row rather than snaking back — same as the importer.
+
+use std::fmt::Debug;
+
+use color_eyre::Result;
+use fbkl_entity::{
+    deadline::DeadlineKind,
+    deadline_queries, draft_pick_queries,
+    rookie_draft_selection::{self, RookieDraftSelectionStatus},
+    rookie_draft_selection_queries,
+    sea_orm::{ConnectionTrait, TransactionTrait},
+    transaction_queries,
+};
+use tracing::instrument;
+
+use super::make_pick::{PickRejection, assert_on_the_clock};
+
+/// Passes the on-the-clock selection (§7.3.1).
+#[instrument(skip(db))]
+pub async fn pass_pick<C>(selection_id: i64, db: &C) -> Result<rookie_draft_selection::Model>
+where
+    C: ConnectionTrait + TransactionTrait + Debug,
+{
+    let db_txn = db.begin().await?;
+
+    // Locking the slate row first is what serializes two clients racing the same pick.
+    let selection_model =
+        rookie_draft_selection_queries::find_selection_by_id_for_update(selection_id, &db_txn)
+            .await?;
+    if selection_model.status != RookieDraftSelectionStatus::Unused {
+        return Err(PickRejection::SelectionAlreadyResolved { selection_id }.into());
+    }
+
+    let draft_pick_model =
+        draft_pick_queries::find_draft_pick_by_id(selection_model.draft_pick_id, &db_txn).await?;
+    let league_id = selection_model.league_id;
+    let end_of_season_year = draft_pick_model.end_of_season_year;
+
+    assert_on_the_clock(&selection_model, end_of_season_year, &db_txn).await?;
+
+    let deadline_model = deadline_queries::find_deadline_for_season_by_type(
+        league_id,
+        end_of_season_year,
+        DeadlineKind::PreseasonRookieDraftStart,
+        &db_txn,
+    )
+    .await?;
+
+    let mut updated_selection_model = rookie_draft_selection_queries::record_selection_result(
+        selection_model,
+        RookieDraftSelectionStatus::Skipped,
+        None,
+        &db_txn,
+    )
+    .await?;
+
+    let transaction_model = transaction_queries::insert_rookie_draft_selection_transaction(
+        &deadline_model,
+        updated_selection_model.id,
+        &db_txn,
+    )
+    .await?;
+    updated_selection_model.transaction_id = Some(transaction_model.id);
+
+    db_txn.commit().await?;
+
+    Ok(updated_selection_model)
+}

--- a/logic/src/rookie_draft/start_draft.rs
+++ b/logic/src/rookie_draft/start_draft.rs
@@ -1,0 +1,74 @@
+//! Starting the live rookie draft (§7.2).
+//!
+//! The scheduler runs this at the `PreseasonRookieDraftStart` deadline, and a commissioner can run
+//! it manually if the scheduler missed. Both paths reach the same function, so every step is
+//! idempotent: an existing slate short-circuits, and [`run_lottery`] replays a stored draw instead
+//! of re-rolling it.
+
+use std::fmt::Debug;
+
+use color_eyre::Result;
+use fbkl_entity::{
+    deadline::DeadlineKind,
+    deadline_queries, draft_pick_queries, league_team_season_standing_queries,
+    rookie_draft_selection_queries,
+    sea_orm::{ConnectionTrait, TransactionTrait},
+};
+use tracing::instrument;
+
+use super::{compute_draft_order, run_lottery};
+
+/// Runs the lottery and persists the full ordered slate of unused selections (§7.2).
+///
+/// Returns `false` when the draft had already been started and nothing was written.
+#[instrument]
+pub async fn start_rookie_draft<C>(league_id: i64, end_of_season_year: i16, db: &C) -> Result<bool>
+where
+    C: ConnectionTrait + TransactionTrait + Debug,
+{
+    // Errors when the deadline is missing, so a league without a scheduled draft cannot start one.
+    deadline_queries::find_deadline_for_season_by_type(
+        league_id,
+        end_of_season_year,
+        DeadlineKind::PreseasonRookieDraftStart,
+        db,
+    )
+    .await?;
+
+    if !rookie_draft_selection_queries::get_selections_for_draft(league_id, end_of_season_year, db)
+        .await?
+        .is_empty()
+    {
+        return Ok(false);
+    }
+
+    let db_txn = db.begin().await?;
+
+    let standings = league_team_season_standing_queries::find_standings_for_league_season(
+        league_id,
+        end_of_season_year,
+        &db_txn,
+    )
+    .await?;
+    let lottery_team_order =
+        run_lottery(league_id, end_of_season_year, &standings, &db_txn).await?;
+    let draft_picks = draft_pick_queries::get_draft_picks_for_league_season(
+        league_id,
+        end_of_season_year,
+        &db_txn,
+    )
+    .await?;
+
+    let draft_slots = compute_draft_order(&standings, &lottery_team_order, &draft_picks)?;
+    rookie_draft_selection_queries::build_draft_slate(
+        league_id,
+        end_of_season_year,
+        draft_slots.iter().map(|slot| slot.draft_pick_id).collect(),
+        &db_txn,
+    )
+    .await?;
+
+    db_txn.commit().await?;
+
+    Ok(true)
+}

--- a/logic/src/rookie_draft/start_draft.rs
+++ b/logic/src/rookie_draft/start_draft.rs
@@ -1,9 +1,9 @@
 //! Starting the live rookie draft (§7.2).
 //!
-//! The scheduler runs this at the `PreseasonRookieDraftStart` deadline, and a commissioner can run
-//! it manually if the scheduler missed. Both paths reach the same function, so every step is
-//! idempotent: an existing slate short-circuits, and [`run_lottery`] replays a stored draw instead
-//! of re-rolling it.
+//! Today only the commissioner's `startRookieDraft` mutation reaches this; wiring the scheduler's
+//! `PreseasonRookieDraftStart` deadline to it is fbkl-rust-z2c. Every step is already idempotent
+//! for that future second caller: an existing slate short-circuits, and [`run_lottery`] replays a
+//! stored draw instead of re-rolling it.
 
 use std::fmt::Debug;
 

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -28,6 +28,7 @@ mod m20260725_000002_alter_auction_add_status_and_owner;
 mod m20260725_000003_create_auction_schedule_tables;
 mod m20260730_000001_rename_auction_close_timestamps;
 mod m20260731_000001_create_veteran_auction_ranking;
+mod m20260731_000002_create_league_team_season_standing;
 
 pub struct Migrator;
 
@@ -56,6 +57,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260725_000003_create_auction_schedule_tables::Migration),
             Box::new(m20260730_000001_rename_auction_close_timestamps::Migration),
             Box::new(m20260731_000001_create_veteran_auction_ranking::Migration),
+            Box::new(m20260731_000002_create_league_team_season_standing::Migration),
         ]
     }
 }

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -29,6 +29,7 @@ mod m20260725_000003_create_auction_schedule_tables;
 mod m20260730_000001_rename_auction_close_timestamps;
 mod m20260731_000001_create_veteran_auction_ranking;
 mod m20260731_000002_create_league_team_season_standing;
+mod m20260731_000003_create_rookie_draft_lottery_tables;
 
 pub struct Migrator;
 
@@ -58,6 +59,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260730_000001_rename_auction_close_timestamps::Migration),
             Box::new(m20260731_000001_create_veteran_auction_ranking::Migration),
             Box::new(m20260731_000002_create_league_team_season_standing::Migration),
+            Box::new(m20260731_000003_create_rookie_draft_lottery_tables::Migration),
         ]
     }
 }

--- a/migration/src/m20260731_000002_create_league_team_season_standing.rs
+++ b/migration/src/m20260731_000002_create_league_team_season_standing.rs
@@ -1,0 +1,154 @@
+//! One row per team per season holding the standings inputs the rookie draft consumes (rules §7.2).
+//!
+//! FBKL cannot compute these itself — they come from the external league host, entered by the
+//! commissioner. `mid_season_rank` is the ≈2/3-season snapshot frozen at a set week (§7.2.3) that
+//! drives lottery odds and the rounds 2–5 order; `regular_season_rank` is the final standings, used
+//! only as a tie-break; `playoff_finish` orders the playoff teams. Deliberately immutable stored
+//! data, never recomputed from a live feed.
+
+use sea_orm_migration::prelude::*;
+
+use crate::{
+    m20220924_004529_create_league_tables::{League, Team},
+    set_auto_updated_at_on_table,
+};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(LeagueTeamSeasonStanding::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(LeagueTeamSeasonStanding::Id)
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(LeagueTeamSeasonStanding::LeagueId)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(LeagueTeamSeasonStanding::TeamId)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(LeagueTeamSeasonStanding::EndOfSeasonYear)
+                            .small_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(LeagueTeamSeasonStanding::RegularSeasonRank)
+                            .small_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(LeagueTeamSeasonStanding::MidSeasonRank)
+                            .small_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(LeagueTeamSeasonStanding::MadePlayoffs)
+                            .boolean()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(LeagueTeamSeasonStanding::PlayoffFinish).small_integer())
+                    .col(
+                        ColumnDef::new(LeagueTeamSeasonStanding::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .extra("DEFAULT CURRENT_TIMESTAMP".to_string()),
+                    )
+                    .col(
+                        ColumnDef::new(LeagueTeamSeasonStanding::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .extra("DEFAULT CURRENT_TIMESTAMP".to_string()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        set_auto_updated_at_on_table(manager, LeagueTeamSeasonStanding::Table.to_string()).await?;
+
+        manager
+            .create_foreign_key(
+                ForeignKey::create()
+                    .name("league_team_season_standing_fk_league")
+                    .from(
+                        LeagueTeamSeasonStanding::Table,
+                        LeagueTeamSeasonStanding::LeagueId,
+                    )
+                    .to(League::Table, League::Id)
+                    .on_delete(ForeignKeyAction::Cascade)
+                    .on_update(ForeignKeyAction::Cascade)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_foreign_key(
+                ForeignKey::create()
+                    .name("league_team_season_standing_fk_team")
+                    .from(
+                        LeagueTeamSeasonStanding::Table,
+                        LeagueTeamSeasonStanding::TeamId,
+                    )
+                    .to(Team::Table, Team::Id)
+                    .on_delete(ForeignKeyAction::Cascade)
+                    .on_update(ForeignKeyAction::Cascade)
+                    .to_owned(),
+            )
+            .await?;
+
+        // A team has at most one standings row per season.
+        manager
+            .create_index(
+                IndexCreateStatement::new()
+                    .name("league_team_season_standing_league_season_team")
+                    .table(LeagueTeamSeasonStanding::Table)
+                    .col(LeagueTeamSeasonStanding::LeagueId)
+                    .col(LeagueTeamSeasonStanding::EndOfSeasonYear)
+                    .col(LeagueTeamSeasonStanding::TeamId)
+                    .unique()
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(LeagueTeamSeasonStanding::Table)
+                    .if_exists()
+                    .to_owned(),
+            )
+            .await
+    }
+}
+
+/// Learn more at <https://docs.rs/sea-query#iden>
+#[derive(Iden)]
+pub enum LeagueTeamSeasonStanding {
+    Table,
+    Id,
+    LeagueId,
+    TeamId,
+    EndOfSeasonYear,
+    RegularSeasonRank,
+    MidSeasonRank,
+    MadePlayoffs,
+    PlayoffFinish,
+    CreatedAt,
+    UpdatedAt,
+}

--- a/migration/src/m20260731_000003_create_rookie_draft_lottery_tables.rs
+++ b/migration/src/m20260731_000003_create_rookie_draft_lottery_tables.rs
@@ -1,0 +1,272 @@
+//! Lottery audit storage plus the pick-owner denormalization the live rookie draft needs (rules §7.2).
+//!
+//! `rookie_draft_selection.current_owner_team_id` is copied from `draft_pick` when the slate is
+//! built, so a traded pick is made by the acquirer without re-joining `draft_pick` on every board
+//! render. Existing (imported) rows are backfilled from their draft pick.
+//!
+//! `rookie_draft_lottery` stores the RNG seed and a human-readable draw log so the six drawn
+//! first-round slots can be re-verified independently; `rookie_draft_lottery_pick` stores each
+//! drawn slot with the ball count that won it. Picks 7–12 are deterministic from `playoff_finish`
+//! and need no storage.
+
+use sea_orm_migration::{
+    prelude::*,
+    sea_orm::{DatabaseBackend, Statement},
+};
+
+use crate::{
+    m20220924_004529_create_league_tables::{League, Team},
+    set_auto_updated_at_on_table,
+};
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+async fn run_sql(manager: &SchemaManager<'_>, sql: &str) -> Result<(), DbErr> {
+    manager
+        .get_connection()
+        .execute(Statement::from_string(DatabaseBackend::Postgres, sql))
+        .await
+        .map(|_| ())
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        run_sql(
+            manager,
+            "ALTER TABLE rookie_draft_selection ADD COLUMN current_owner_team_id BIGINT",
+        )
+        .await?;
+        run_sql(
+            manager,
+            "UPDATE rookie_draft_selection AS rds
+                SET current_owner_team_id = dp.current_owner_team_id
+                FROM draft_pick AS dp
+                WHERE dp.id = rds.draft_pick_id",
+        )
+        .await?;
+        run_sql(
+            manager,
+            "ALTER TABLE rookie_draft_selection
+                ALTER COLUMN current_owner_team_id SET NOT NULL,
+                ADD CONSTRAINT rookie_draft_selection_fk_current_owner_team
+                    FOREIGN KEY (current_owner_team_id) REFERENCES team(id)
+                    ON UPDATE CASCADE ON DELETE NO ACTION",
+        )
+        .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(RookieDraftLottery::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(RookieDraftLottery::Id)
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(RookieDraftLottery::LeagueId)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RookieDraftLottery::EndOfSeasonYear)
+                            .small_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RookieDraftLottery::RngSeed)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(ColumnDef::new(RookieDraftLottery::RngLog).text())
+                    .col(
+                        ColumnDef::new(RookieDraftLottery::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .extra("DEFAULT CURRENT_TIMESTAMP".to_string()),
+                    )
+                    .col(
+                        ColumnDef::new(RookieDraftLottery::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .extra("DEFAULT CURRENT_TIMESTAMP".to_string()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        set_auto_updated_at_on_table(manager, RookieDraftLottery::Table.to_string()).await?;
+
+        manager
+            .create_foreign_key(
+                ForeignKey::create()
+                    .name("rookie_draft_lottery_fk_league")
+                    .from(RookieDraftLottery::Table, RookieDraftLottery::LeagueId)
+                    .to(League::Table, League::Id)
+                    .on_delete(ForeignKeyAction::Cascade)
+                    .on_update(ForeignKeyAction::Cascade)
+                    .to_owned(),
+            )
+            .await?;
+
+        // One lottery per league season — the unique index is what makes re-running it a no-op.
+        manager
+            .create_index(
+                IndexCreateStatement::new()
+                    .name("rookie_draft_lottery_league_season")
+                    .table(RookieDraftLottery::Table)
+                    .col(RookieDraftLottery::LeagueId)
+                    .col(RookieDraftLottery::EndOfSeasonYear)
+                    .unique()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_table(
+                Table::create()
+                    .table(RookieDraftLotteryPick::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(RookieDraftLotteryPick::Id)
+                            .big_integer()
+                            .not_null()
+                            .auto_increment()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(RookieDraftLotteryPick::RookieDraftLotteryId)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RookieDraftLotteryPick::PickNumber)
+                            .small_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RookieDraftLotteryPick::TeamId)
+                            .big_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RookieDraftLotteryPick::BallsHeld)
+                            .small_integer()
+                            .not_null(),
+                    )
+                    .col(
+                        ColumnDef::new(RookieDraftLotteryPick::CreatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .extra("DEFAULT CURRENT_TIMESTAMP".to_string()),
+                    )
+                    .col(
+                        ColumnDef::new(RookieDraftLotteryPick::UpdatedAt)
+                            .timestamp_with_time_zone()
+                            .not_null()
+                            .extra("DEFAULT CURRENT_TIMESTAMP".to_string()),
+                    )
+                    .to_owned(),
+            )
+            .await?;
+
+        set_auto_updated_at_on_table(manager, RookieDraftLotteryPick::Table.to_string()).await?;
+
+        manager
+            .create_foreign_key(
+                ForeignKey::create()
+                    .name("rookie_draft_lottery_pick_fk_lottery")
+                    .from(
+                        RookieDraftLotteryPick::Table,
+                        RookieDraftLotteryPick::RookieDraftLotteryId,
+                    )
+                    .to(RookieDraftLottery::Table, RookieDraftLottery::Id)
+                    .on_delete(ForeignKeyAction::Cascade)
+                    .on_update(ForeignKeyAction::Cascade)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_foreign_key(
+                ForeignKey::create()
+                    .name("rookie_draft_lottery_pick_fk_team")
+                    .from(
+                        RookieDraftLotteryPick::Table,
+                        RookieDraftLotteryPick::TeamId,
+                    )
+                    .to(Team::Table, Team::Id)
+                    .on_delete(ForeignKeyAction::Cascade)
+                    .on_update(ForeignKeyAction::Cascade)
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                IndexCreateStatement::new()
+                    .name("rookie_draft_lottery_pick_lottery_pick_number")
+                    .table(RookieDraftLotteryPick::Table)
+                    .col(RookieDraftLotteryPick::RookieDraftLotteryId)
+                    .col(RookieDraftLotteryPick::PickNumber)
+                    .unique()
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(RookieDraftLotteryPick::Table)
+                    .if_exists()
+                    .to_owned(),
+            )
+            .await?;
+        manager
+            .drop_table(
+                Table::drop()
+                    .table(RookieDraftLottery::Table)
+                    .if_exists()
+                    .to_owned(),
+            )
+            .await?;
+        run_sql(
+            manager,
+            "ALTER TABLE rookie_draft_selection DROP COLUMN current_owner_team_id",
+        )
+        .await
+    }
+}
+
+/// Learn more at <https://docs.rs/sea-query#iden>
+#[derive(Iden)]
+pub enum RookieDraftLottery {
+    Table,
+    Id,
+    LeagueId,
+    EndOfSeasonYear,
+    RngSeed,
+    RngLog,
+    CreatedAt,
+    UpdatedAt,
+}
+
+/// Learn more at <https://docs.rs/sea-query#iden>
+#[derive(Iden)]
+pub enum RookieDraftLotteryPick {
+    Table,
+    Id,
+    RookieDraftLotteryId,
+    PickNumber,
+    TeamId,
+    BallsHeld,
+    CreatedAt,
+    UpdatedAt,
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,6 +18,7 @@ chrono = "0.4"
 color-eyre = "0.6.5"
 dotenv = "0.15.0"
 fbkl-auth = {path = "../auth"}
+fbkl-constants = {path = "../constants"}
 fbkl-entity = {path = "../entity"}
 fbkl-jobs = {path = "../jobs"}
 fbkl-logic = {path = "../logic"}

--- a/server/src/graphql.rs
+++ b/server/src/graphql.rs
@@ -7,7 +7,7 @@ use self::{
     auction::{AuctionMutation, AuctionQuery},
     contract::ContractQuery,
     deadline::{DeadlineMutation, DeadlineQuery},
-    draft::DraftQuery,
+    draft::{DraftMutation, DraftQuery},
     eligibility::{EligibilityMutation, EligibilityQuery},
     keeper::{KeeperMutation, KeeperQuery},
     league::{LeagueMutation, LeagueQuery},
@@ -66,4 +66,5 @@ pub struct MutationRoot(
     DeadlineMutation,
     EligibilityMutation,
     AuctionMutation,
+    DraftMutation,
 );

--- a/server/src/graphql/draft/draft_resolvers.rs
+++ b/server/src/graphql/draft/draft_resolvers.rs
@@ -1,20 +1,43 @@
-//! Read-only rookie draft surface. `makePick` / `passPick` / `lotteryResults` land with
-//! fbkl-rust-2jq (spec 02), which builds the selection logic they need.
+//! The rookie draft surface (spec 02, rules §7): board reads, the audited lottery, the eligible
+//! pool, and the make/pass/lottery/start/standings mutations.
+//!
+//! Every rule lives in `fbkl_logic::rookie_draft`; these resolvers only authorize, fetch and map.
+//! Pick ownership is re-derived from the stored on-the-clock selection, never from a client id.
 
-use async_graphql::{Context, Object, Result, SimpleObject};
-use chrono::Utc;
+use std::collections::HashMap;
+
+use async_graphql::{Context, Error as GraphQlError, InputObject, Object, Result, SimpleObject};
+use color_eyre::Report;
+use fbkl_constants::league_rules::{DRAFT_PICK_ROUNDS, rookie_draft_salary_for_round};
 use fbkl_entity::{
-    deadline_queries::find_most_recent_deadline_by_datetime,
+    contract::{self, RelatedPlayer},
+    contract_queries::{find_contract_by_id, find_contracts_by_ids},
     draft_pick,
-    draft_pick_queries::get_draft_picks_for_league_season,
+    draft_pick_queries::{find_draft_pick_by_id, get_draft_picks_for_league_season},
+    league_team_season_standing_queries::{
+        NewLeagueTeamSeasonStanding, find_standings_for_league_season,
+        upsert_standings_for_league_season,
+    },
+    rookie_draft_lottery_queries::{find_lottery_for_league_season, find_lottery_picks},
     rookie_draft_selection::{self, RookieDraftSelectionStatus},
-    rookie_draft_selection_queries::find_rookie_draft_selections_for_league_season,
+    rookie_draft_selection_queries::{get_on_the_clock_selection, get_selections_for_draft},
     sea_orm::DatabaseConnection,
+};
+use fbkl_logic::{
+    eligibility::build_rookie_draft_eligible_pool,
+    rookie_draft::{
+        PickRejection, make_pick, pass_pick, re_draft_ban_check, run_lottery, start_rookie_draft,
+    },
 };
 
 use crate::graphql::{
-    ErrorCode, LeagueRoleGuard, RoleRequirement, code_error, require_league_role,
+    ErrorCode, LeagueRoleGuard, RoleRequirement, code_error, contract::Contract, current_season,
+    graphql_error, player::LeagueOrRealPlayer, require_league_role,
 };
+
+/// The eligible pool spans every rookie-eligible player, so a page is always bounded (same
+/// convention as the transaction feed and auction bid history).
+const MAX_PAGE_SIZE: usize = 100;
 
 #[derive(SimpleObject)]
 pub struct DraftPick {
@@ -39,7 +62,9 @@ impl DraftPick {
     }
 }
 
-/// A used or skipped pick. `contractId` is the signed rookie contract when a player was selected.
+/// One slate slot. `contract` is the signed rookie contract when a player was selected — its
+/// `leagueOrRealPlayer` field resolves through the player `DataLoader`s, so a 60-cell board is
+/// still two player queries.
 #[derive(SimpleObject)]
 pub struct RookieDraftSelection {
     pub id: i64,
@@ -47,26 +72,95 @@ pub struct RookieDraftSelection {
     pub status: RookieDraftSelectionStatus,
     pub contract_id: Option<i64>,
     pub draft_pick_id: i64,
+    pub current_owner_team_id: i64,
+    pub round: Option<i16>,
+    /// The fixed RD salary this slot signs at (§7.4.1). Null when the round is unknown.
+    pub salary: Option<i16>,
+    pub contract: Option<Contract>,
 }
 
 impl RookieDraftSelection {
-    const fn from_model(model: &rookie_draft_selection::Model) -> Self {
-        Self {
+    fn from_model(
+        model: &rookie_draft_selection::Model,
+        round: Option<i16>,
+        contract_model: Option<&contract::Model>,
+    ) -> Result<Self> {
+        let contract = contract_model
+            .map(Contract::from_model)
+            .transpose()
+            .map_err(|err| {
+                tracing::error!(error = ?err, "rookie draft contract has no player");
+                code_error(ErrorCode::Internal)
+            })?;
+
+        Ok(Self {
             id: model.id,
             order: model.order,
             status: model.status,
             contract_id: model.contract_id,
             draft_pick_id: model.draft_pick_id,
-        }
+            current_owner_team_id: model.current_owner_team_id,
+            round,
+            salary: round.and_then(salary_for_round),
+            contract,
+        })
     }
 }
 
-/// A season's draft: every pick plus the selections made so far.
+/// A season's draft: every pick, the slate, and who is on the clock.
 #[derive(SimpleObject)]
 pub struct DraftBoard {
     pub end_of_season_year: i16,
     pub picks: Vec<DraftPick>,
     pub selections: Vec<RookieDraftSelection>,
+    /// False until `startRookieDraft` has built the slate.
+    pub started: bool,
+    pub on_the_clock_selection_id: Option<i64>,
+    pub on_the_clock_team_id: Option<i64>,
+}
+
+#[derive(SimpleObject)]
+pub struct RookieDraftLotteryPick {
+    pub pick_number: i16,
+    pub team_id: i64,
+    pub balls_held: i16,
+}
+
+/// The audited lottery: the committed seed plus the drawn slots, so the draw can be re-verified.
+#[derive(SimpleObject)]
+pub struct RookieDraftLottery {
+    pub end_of_season_year: i16,
+    pub rng_seed: i64,
+    pub rng_log: Option<String>,
+    pub picks: Vec<RookieDraftLotteryPick>,
+}
+
+/// A pool entry the UI can show greyed out with a reason instead of failing at pick time.
+#[derive(SimpleObject)]
+pub struct EligibleRookie {
+    pub player: LeagueOrRealPlayer,
+    pub banned: bool,
+    pub banned_reason: Option<String>,
+}
+
+/// One page of the eligible pool.
+#[derive(SimpleObject)]
+pub struct PagedEligibleRookies {
+    pub items: Vec<EligibleRookie>,
+    pub total_items: u64,
+}
+
+/// One team's frozen standings inputs (§7.2), entered by the commissioner.
+#[derive(InputObject)]
+pub struct LeagueTeamSeasonStandingInput {
+    pub team_id: i64,
+    /// Final regular-season rank, 1 = best.
+    pub regular_season_rank: i16,
+    /// The ~2/3-season snapshot that drives lottery odds and the rounds 2-5 order.
+    pub mid_season_rank: i16,
+    pub made_playoffs: bool,
+    /// 1 = champion .. 6 = first-round loser; null for non-playoff teams.
+    pub playoff_finish: Option<i16>,
 }
 
 #[derive(Default)]
@@ -74,7 +168,7 @@ pub struct DraftQuery;
 
 #[Object]
 impl DraftQuery {
-    /// The season's picks and the selections made against them. Defaults to the current season.
+    /// The season's slate with status, on-the-clock team, and each pick's player and salary.
     #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Member)")]
     async fn draft_board(
         &self,
@@ -82,24 +176,45 @@ impl DraftQuery {
         end_of_season_year: Option<i16>,
     ) -> Result<DraftBoard> {
         let db = ctx.data_unchecked::<DatabaseConnection>();
-        let (_, caller_team) = require_league_role(ctx, RoleRequirement::Member).await?;
-        let season = season_or_current(ctx, caller_team.league_id, end_of_season_year).await?;
+        let (league_id, season) = league_and_season(ctx, end_of_season_year).await?;
 
-        let picks = get_draft_picks_for_league_season(caller_team.league_id, season, db)
+        let picks = get_draft_picks_for_league_season(league_id, season, db)
             .await
             .map_err(|err| internal("failed to load draft picks", &err))?;
-        let selections =
-            find_rookie_draft_selections_for_league_season(caller_team.league_id, season, db)
-                .await
-                .map_err(|err| internal("failed to load rookie draft selections", &err))?;
+        let selections = get_selections_for_draft(league_id, season, db)
+            .await
+            .map_err(|err| internal("failed to load rookie draft selections", &err))?;
+
+        let rounds: HashMap<i64, i16> = picks.iter().map(|pick| (pick.id, pick.round)).collect();
+        let contract_ids = selections.iter().filter_map(|s| s.contract_id).collect();
+        let contracts: HashMap<i64, contract::Model> = find_contracts_by_ids(contract_ids, db)
+            .await
+            .map_err(|err| internal("failed to load rookie draft contracts", &err))?
+            .into_iter()
+            .map(|model| (model.id, model))
+            .collect();
+
+        let on_the_clock = selections
+            .iter()
+            .filter(|s| s.status == RookieDraftSelectionStatus::Unused)
+            .min_by_key(|s| s.order);
 
         Ok(DraftBoard {
             end_of_season_year: season,
             picks: picks.iter().map(DraftPick::from_model).collect(),
+            started: !selections.is_empty(),
+            on_the_clock_selection_id: on_the_clock.map(|s| s.id),
+            on_the_clock_team_id: on_the_clock.map(|s| s.current_owner_team_id),
             selections: selections
                 .iter()
-                .map(RookieDraftSelection::from_model)
-                .collect(),
+                .map(|model| {
+                    RookieDraftSelection::from_model(
+                        model,
+                        rounds.get(&model.draft_pick_id).copied(),
+                        model.contract_id.and_then(|id| contracts.get(&id)),
+                    )
+                })
+                .collect::<Result<_>>()?,
         })
     }
 
@@ -111,35 +226,402 @@ impl DraftQuery {
         end_of_season_year: Option<i16>,
     ) -> Result<Vec<DraftPick>> {
         let db = ctx.data_unchecked::<DatabaseConnection>();
-        let (_, caller_team) = require_league_role(ctx, RoleRequirement::Member).await?;
-        let season = season_or_current(ctx, caller_team.league_id, end_of_season_year).await?;
+        let (league_id, season) = league_and_season(ctx, end_of_season_year).await?;
 
-        let picks = get_draft_picks_for_league_season(caller_team.league_id, season, db)
+        let picks = get_draft_picks_for_league_season(league_id, season, db)
             .await
             .map_err(|err| internal("failed to load draft picks", &err))?;
 
         Ok(picks.iter().map(DraftPick::from_model).collect())
     }
-}
 
-async fn season_or_current(
-    ctx: &Context<'_>,
-    league_id: i64,
-    end_of_season_year: Option<i16>,
-) -> Result<i16> {
-    if let Some(year) = end_of_season_year {
-        return Ok(year);
+    /// The audited lottery result, or null before the lottery has been drawn.
+    #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Member)")]
+    async fn rookie_draft_lottery(
+        &self,
+        ctx: &Context<'_>,
+        end_of_season_year: Option<i16>,
+    ) -> Result<Option<RookieDraftLottery>> {
+        let db = ctx.data_unchecked::<DatabaseConnection>();
+        let (league_id, season) = league_and_season(ctx, end_of_season_year).await?;
+
+        let Some(lottery) = find_lottery_for_league_season(league_id, season, db)
+            .await
+            .map_err(|err| internal("failed to load the rookie draft lottery", &err))?
+        else {
+            return Ok(None);
+        };
+
+        let picks = find_lottery_picks(lottery.id, db)
+            .await
+            .map_err(|err| internal("failed to load the lottery picks", &err))?;
+
+        Ok(Some(RookieDraftLottery {
+            end_of_season_year: lottery.end_of_season_year,
+            rng_seed: lottery.rng_seed,
+            rng_log: lottery.rng_log,
+            picks: picks
+                .into_iter()
+                .map(|pick| RookieDraftLotteryPick {
+                    pick_number: pick.pick_number,
+                    team_id: pick.team_id,
+                    balls_held: pick.balls_held,
+                })
+                .collect(),
+        }))
     }
 
-    let db = ctx.data_unchecked::<DatabaseConnection>();
-    let deadline = find_most_recent_deadline_by_datetime(league_id, Utc::now().fixed_offset(), db)
-        .await
-        .map_err(|err| internal("failed to resolve the current season", &err))?;
+    /// One page of the §7.5 eligible pool, flagging players who cannot be drafted and why.
+    #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Member)")]
+    async fn eligible_rookie_pool(
+        &self,
+        ctx: &Context<'_>,
+        end_of_season_year: Option<i16>,
+        #[graphql(default = 0)] page: usize,
+        #[graphql(default = 25)] page_size: usize,
+    ) -> Result<PagedEligibleRookies> {
+        let db = ctx.data_unchecked::<DatabaseConnection>();
+        let (league_id, season) = league_and_season(ctx, end_of_season_year).await?;
 
-    Ok(deadline.end_of_season_year)
+        let pool = build_rookie_draft_eligible_pool(league_id, season, db)
+            .await
+            .map_err(|err| internal("failed to build the rookie draft pool", &err))?;
+        let ban = re_draft_ban_check(league_id, season, db)
+            .await
+            .map_err(|err| internal("failed to check the re-draft ban", &err))?;
+        let drafted = drafted_player_keys(league_id, season, db).await?;
+
+        // The pool is a computed list rather than a query, so the page is a slice of it.
+        let total_items = pool.len() as u64;
+        let page_size = page_size.clamp(1, MAX_PAGE_SIZE);
+        let items = pool
+            .into_iter()
+            .skip(page.saturating_mul(page_size))
+            .take(page_size)
+            .map(|related_player| {
+                let key = player_key(&related_player);
+                let banned_reason = if drafted.contains(&key) {
+                    Some("Already drafted in this draft.".to_owned())
+                } else if ban.is_banned(key.0, key.1) {
+                    Some("Dropped during this draft and cannot be re-drafted (§7.3.4).".to_owned())
+                } else {
+                    None
+                };
+
+                EligibleRookie {
+                    player: LeagueOrRealPlayer::from_related_player(related_player),
+                    banned: banned_reason.is_some(),
+                    banned_reason,
+                }
+            })
+            .collect();
+
+        Ok(PagedEligibleRookies { items, total_items })
+    }
+}
+
+#[derive(Default)]
+pub struct DraftMutation;
+
+#[Object]
+impl DraftMutation {
+    /// Ingests the frozen standings inputs the draft order and lottery odds derive from (§7.2).
+    #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Commissioner)")]
+    async fn save_league_team_season_standings(
+        &self,
+        ctx: &Context<'_>,
+        end_of_season_year: i16,
+        standings: Vec<LeagueTeamSeasonStandingInput>,
+    ) -> Result<i32> {
+        let db = ctx.data_unchecked::<DatabaseConnection>();
+        let (_, caller_team) = require_league_role(ctx, RoleRequirement::Commissioner).await?;
+
+        let rows: Vec<NewLeagueTeamSeasonStanding> = standings
+            .into_iter()
+            .map(|row| NewLeagueTeamSeasonStanding {
+                team_id: row.team_id,
+                regular_season_rank: row.regular_season_rank,
+                mid_season_rank: row.mid_season_rank,
+                made_playoffs: row.made_playoffs,
+                playoff_finish: row.playoff_finish,
+            })
+            .collect();
+        let saved = i32::try_from(rows.len())
+            .map_err(|_| graphql_error(ErrorCode::BadRequest, "too many standings rows"))?;
+
+        upsert_standings_for_league_season(caller_team.league_id, end_of_season_year, rows, db)
+            .await
+            .map_err(|err| internal("failed to save the season standings", &err))?;
+
+        Ok(saved)
+    }
+
+    /// Draws the first-round lottery (§7.2.5), returning the six team ids in drawn order.
+    /// Audit detail (seed, ball counts) comes back from the `rookieDraftLottery` query.
+    #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Commissioner)")]
+    async fn run_rookie_draft_lottery(
+        &self,
+        ctx: &Context<'_>,
+        end_of_season_year: i16,
+    ) -> Result<Vec<i64>> {
+        let db = ctx.data_unchecked::<DatabaseConnection>();
+        let (_, caller_team) = require_league_role(ctx, RoleRequirement::Commissioner).await?;
+        let league_id = caller_team.league_id;
+
+        if find_lottery_for_league_season(league_id, end_of_season_year, db)
+            .await
+            .map_err(|err| internal("failed to check for an existing lottery", &err))?
+            .is_some()
+        {
+            return Err(code_error(ErrorCode::DraftLotteryAlreadyRun));
+        }
+
+        let standings = find_standings_for_league_season(league_id, end_of_season_year, db)
+            .await
+            .map_err(|err| internal("failed to load the season standings", &err))?;
+
+        run_lottery(league_id, end_of_season_year, &standings, db)
+            .await
+            .map_err(|err| {
+                tracing::error!(error = ?err, "failed to run the rookie draft lottery");
+                graphql_error(ErrorCode::BadRequest, err.to_string())
+            })
+    }
+
+    /// Runs the lottery if needed, computes the order and builds the slate. False = already started.
+    #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Commissioner)")]
+    async fn start_rookie_draft(&self, ctx: &Context<'_>, end_of_season_year: i16) -> Result<bool> {
+        let db = ctx.data_unchecked::<DatabaseConnection>();
+        let (_, caller_team) = require_league_role(ctx, RoleRequirement::Commissioner).await?;
+
+        start_rookie_draft(caller_team.league_id, end_of_season_year, db)
+            .await
+            .map_err(|err| {
+                tracing::error!(error = ?err, "failed to start the rookie draft");
+                graphql_error(ErrorCode::BadRequest, err.to_string())
+            })
+    }
+
+    /// Drafts a player with the caller's own on-the-clock pick (§7.3).
+    #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Member)")]
+    async fn make_rookie_draft_pick(
+        &self,
+        ctx: &Context<'_>,
+        selection_id: i64,
+        player_id: i64,
+        #[graphql(default = false)] is_league_player: bool,
+    ) -> Result<RookieDraftSelection> {
+        let db = ctx.data_unchecked::<DatabaseConnection>();
+        require_own_pick_on_the_clock(ctx, selection_id).await?;
+
+        let selection = make_pick(selection_id, player_id, is_league_player, db)
+            .await
+            .map_err(|err| pick_error(&err))?;
+
+        selection_view(&selection, db).await
+    }
+
+    /// Passes the caller's own on-the-clock pick (§7.3.1). The slot stays consumed.
+    #[graphql(guard = "LeagueRoleGuard(RoleRequirement::Member)")]
+    async fn pass_rookie_draft_pick(
+        &self,
+        ctx: &Context<'_>,
+        selection_id: i64,
+    ) -> Result<RookieDraftSelection> {
+        let db = ctx.data_unchecked::<DatabaseConnection>();
+        require_own_pick_on_the_clock(ctx, selection_id).await?;
+
+        let selection = pass_pick(selection_id, db)
+            .await
+            .map_err(|err| pick_error(&err))?;
+
+        selection_view(&selection, db).await
+    }
+}
+
+/// Rejects anyone but the current owner of the pick that is actually on the clock. The owning team
+/// comes from the stored selection row, so a client-supplied team id can never widen access.
+async fn require_own_pick_on_the_clock(ctx: &Context<'_>, selection_id: i64) -> Result<()> {
+    let db = ctx.data_unchecked::<DatabaseConnection>();
+    let (_, caller_team) = require_league_role(ctx, RoleRequirement::Member).await?;
+    let season = current_season(ctx, caller_team.league_id).await?;
+
+    let on_the_clock = get_on_the_clock_selection(caller_team.league_id, season, db)
+        .await
+        .map_err(|err| internal("failed to load the on-the-clock selection", &err))?
+        .ok_or_else(|| code_error(ErrorCode::DraftNotStarted))?;
+
+    if on_the_clock.id != selection_id {
+        return Err(code_error(ErrorCode::DraftNotOnTheClock));
+    }
+    if on_the_clock.current_owner_team_id != caller_team.id {
+        return Err(code_error(ErrorCode::Forbidden));
+    }
+
+    Ok(())
+}
+
+/// A refused pick is the client's fault and gets its own code; anything else is a server fault.
+fn pick_error(error: &Report) -> GraphQlError {
+    let Some(rejection) = error.downcast_ref::<PickRejection>() else {
+        tracing::error!(error = ?error, "failed to resolve a rookie draft pick");
+        return code_error(ErrorCode::Internal);
+    };
+
+    let code = match rejection {
+        PickRejection::DraftNotStarted => ErrorCode::DraftNotStarted,
+        PickRejection::NotOnTheClock { .. } => ErrorCode::DraftNotOnTheClock,
+        PickRejection::SelectionAlreadyResolved { .. } => ErrorCode::DraftSelectionResolved,
+        PickRejection::PlayerNotEligible => ErrorCode::DraftPlayerNotEligible,
+        PickRejection::ReDraftBanned => ErrorCode::DraftReDraftBanned,
+        PickRejection::NoRosterSpace { .. } => ErrorCode::DraftNoRosterSpace,
+    };
+
+    graphql_error(code, rejection.to_string())
+}
+
+/// Re-reads the round and contract a mutated selection needs for its GraphQL shape.
+async fn selection_view(
+    model: &rookie_draft_selection::Model,
+    db: &DatabaseConnection,
+) -> Result<RookieDraftSelection> {
+    let draft_pick_model = find_draft_pick_by_id(model.draft_pick_id, db)
+        .await
+        .map_err(|err| internal("failed to load the selection's draft pick", &err))?;
+
+    let contract_model = match model.contract_id {
+        Some(contract_id) => Some(
+            find_contract_by_id(contract_id, db)
+                .await
+                .map_err(|err| internal("failed to load the drafted contract", &err))?,
+        ),
+        None => None,
+    };
+
+    RookieDraftSelection::from_model(model, Some(draft_pick_model.round), contract_model.as_ref())
+}
+
+/// The `(id, is_league_player)` keys of players already drafted in this draft.
+async fn drafted_player_keys(
+    league_id: i64,
+    end_of_season_year: i16,
+    db: &DatabaseConnection,
+) -> Result<Vec<(i64, bool)>> {
+    let selections = get_selections_for_draft(league_id, end_of_season_year, db)
+        .await
+        .map_err(|err| internal("failed to load rookie draft selections", &err))?;
+    let contract_ids = selections.iter().filter_map(|s| s.contract_id).collect();
+
+    let contracts = find_contracts_by_ids(contract_ids, db)
+        .await
+        .map_err(|err| internal("failed to load rookie draft contracts", &err))?;
+
+    Ok(contracts
+        .iter()
+        .filter_map(|contract_model| {
+            contract_model.player_id.map_or_else(
+                || {
+                    contract_model
+                        .league_player_id
+                        .map(|league_player_id| (league_player_id, true))
+                },
+                |player_id| Some((player_id, false)),
+            )
+        })
+        .collect())
+}
+
+const fn player_key(related_player: &RelatedPlayer) -> (i64, bool) {
+    match related_player {
+        RelatedPlayer::LeaguePlayer(model) => (model.id, true),
+        RelatedPlayer::Player(model) => (model.id, false),
+    }
+}
+
+/// Guarded so a stored round outside 1..=5 yields null instead of panicking mid-resolver.
+fn salary_for_round(round: i16) -> Option<i16> {
+    (1..=DRAFT_PICK_ROUNDS)
+        .contains(&round)
+        .then(|| rookie_draft_salary_for_round(round))
+}
+
+/// The caller's league plus the season to read, defaulting to the current one.
+async fn league_and_season(
+    ctx: &Context<'_>,
+    end_of_season_year: Option<i16>,
+) -> Result<(i64, i16)> {
+    let (_, caller_team) = require_league_role(ctx, RoleRequirement::Member).await?;
+    let season = match end_of_season_year {
+        Some(year) => year,
+        None => current_season(ctx, caller_team.league_id).await?,
+    };
+    Ok((caller_team.league_id, season))
 }
 
 fn internal(message: &str, error: &color_eyre::Report) -> async_graphql::Error {
     tracing::error!(error = ?error, message);
     code_error(ErrorCode::Internal)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn code_of(error: &GraphQlError) -> Option<async_graphql::Value> {
+        error
+            .extensions
+            .as_ref()
+            .and_then(|ext| ext.get("code"))
+            .cloned()
+    }
+
+    #[test]
+    fn every_pick_rejection_gets_its_own_code() {
+        let cases = [
+            (PickRejection::DraftNotStarted, "DRAFT_NOT_STARTED"),
+            (
+                PickRejection::NotOnTheClock {
+                    selection_id: 1,
+                    on_the_clock_order: 2,
+                },
+                "DRAFT_NOT_ON_THE_CLOCK",
+            ),
+            (
+                PickRejection::SelectionAlreadyResolved { selection_id: 1 },
+                "DRAFT_SELECTION_RESOLVED",
+            ),
+            (
+                PickRejection::PlayerNotEligible,
+                "DRAFT_PLAYER_NOT_ELIGIBLE",
+            ),
+            (PickRejection::ReDraftBanned, "DRAFT_RE_DRAFT_BANNED"),
+            (
+                PickRejection::NoRosterSpace {
+                    roster_used: 32,
+                    roster_limit: 32,
+                },
+                "DRAFT_NO_ROSTER_SPACE",
+            ),
+        ];
+
+        for (rejection, expected_code) in cases {
+            let error = pick_error(&Report::new(rejection));
+            assert_eq!(code_of(&error), Some(expected_code.into()));
+        }
+    }
+
+    #[test]
+    fn other_pick_failures_stay_internal() {
+        let error = pick_error(&color_eyre::eyre::eyre!("db exploded"));
+
+        assert_eq!(code_of(&error), Some("INTERNAL".into()));
+    }
+
+    #[test]
+    fn salary_is_null_outside_the_draft_rounds() {
+        assert_eq!(salary_for_round(1), Some(4));
+        assert_eq!(salary_for_round(5), Some(1));
+        assert_eq!(salary_for_round(0), None);
+        assert_eq!(salary_for_round(6), None);
+    }
 }

--- a/server/src/graphql/draft/draft_resolvers.rs
+++ b/server/src/graphql/draft/draft_resolvers.rs
@@ -309,7 +309,7 @@ impl DraftQuery {
                 };
 
                 EligibleRookie {
-                    player: LeagueOrRealPlayer::from_related_player(related_player),
+                    player: LeagueOrRealPlayer::from_related_player(related_player, season),
                     banned: banned_reason.is_some(),
                     banned_reason,
                 }

--- a/server/src/graphql/error.rs
+++ b/server/src/graphql/error.rs
@@ -41,6 +41,20 @@ pub enum ErrorCode {
     BidOriginalOwner,
     /// Season config (tiers, ranked list) is locked because the veteran auction pool is assembled (rules §6.3.6).
     VeteranAuctionStarted,
+    /// The rookie draft has not been started for this league season.
+    DraftNotStarted,
+    /// The referenced selection is not the one on the clock.
+    DraftNotOnTheClock,
+    /// The referenced selection was already used or passed.
+    DraftSelectionResolved,
+    /// The player is not in the rookie draft eligible pool (rules §7.5).
+    DraftPlayerNotEligible,
+    /// The player was dropped during this draft and cannot be re-drafted (rules §7.3.4).
+    DraftReDraftBanned,
+    /// Drafting would leave the picking team over its roster limit (rules §7.3.2).
+    DraftNoRosterSpace,
+    /// The season's lottery has already been drawn and cannot be re-rolled (rules §7.2.5).
+    DraftLotteryAlreadyRun,
     /// Server-side fault; message is deliberately generic.
     Internal,
 }
@@ -62,6 +76,13 @@ impl ErrorCode {
             Self::BidNoRosterSpace => "BID_NO_ROSTER_SPACE",
             Self::BidOriginalOwner => "BID_ORIGINAL_OWNER",
             Self::VeteranAuctionStarted => "VETERAN_AUCTION_STARTED",
+            Self::DraftNotStarted => "DRAFT_NOT_STARTED",
+            Self::DraftNotOnTheClock => "DRAFT_NOT_ON_THE_CLOCK",
+            Self::DraftSelectionResolved => "DRAFT_SELECTION_RESOLVED",
+            Self::DraftPlayerNotEligible => "DRAFT_PLAYER_NOT_ELIGIBLE",
+            Self::DraftReDraftBanned => "DRAFT_RE_DRAFT_BANNED",
+            Self::DraftNoRosterSpace => "DRAFT_NO_ROSTER_SPACE",
+            Self::DraftLotteryAlreadyRun => "DRAFT_LOTTERY_ALREADY_RUN",
             Self::Internal => "INTERNAL",
         }
     }
@@ -86,6 +107,13 @@ impl ErrorCode {
             Self::VeteranAuctionStarted => {
                 "the veteran auction has started, so this season's config is locked"
             }
+            Self::DraftNotStarted => "the rookie draft has not started",
+            Self::DraftNotOnTheClock => "that pick is not on the clock",
+            Self::DraftSelectionResolved => "that pick has already been used or passed",
+            Self::DraftPlayerNotEligible => "that player is not eligible for the rookie draft",
+            Self::DraftReDraftBanned => "that player was dropped during this draft",
+            Self::DraftNoRosterSpace => "drafting would exceed your roster limit",
+            Self::DraftLotteryAlreadyRun => "this season's lottery has already been drawn",
             Self::Internal => "internal server error",
         }
     }

--- a/transaction-processor/src/lib.rs
+++ b/transaction-processor/src/lib.rs
@@ -258,10 +258,10 @@ async fn dispatch_deadline(
             );
             Ok(())
         }
-        // Rookie draft engine is spec 02 (fbkl-rust-2jq).
+        // Scheduler wiring to `start_rookie_draft` is fbkl-rust-z2c; today only the commissioner mutation starts the draft.
         DeadlineKind::PreseasonRookieDraftStart => {
             info!(
-                "Deadline {:?} (id = {}) recorded; rookie draft engine is spec 02",
+                "Deadline {:?} (id = {}) recorded; rookie draft starts via commissioner mutation",
                 deadline_model.kind, deadline_model.id
             );
             Ok(())


### PR DESCRIPTION
Implements `notes/implementation-specs/02-rookie-draft-engine.md` (backend).

**Stack position: was 4 of 4 (top); #85/#86/#87 have merged**, so this branch is rebased onto `main` and the diff is against it directly.

## What was missing

The entity write-path already existed — `import-data` replays historical drafts through it. What was missing was the *live* draft: the importer cheats by reading the answer from a CSV and back-filling `order`/`Skipped` rows. This produces the same entity rows from live input.

- `ROOKIE_DRAFT_ROUND_SALARIES [4,3,2,1,1]` + `rookie_draft_salary_for_round` and `ROOKIE_DRAFT_LOTTERY_BALLS [6,5,4,3,2,1]` in `constants/` (rule values never live in `logic/`)
- `league_team_season_standing` — the three ingested inputs (mid-season snapshot, final standings, playoff finish), stored immutably because the rules freeze the snapshot at a set week rather than recomputing from a live feed
- `rookie_draft_lottery` + `rookie_draft_lottery_pick` audit tables, and `current_owner_team_id` on `rookie_draft_selection`
- `compute_draft_order`, `run_lottery`, idempotent `start_rookie_draft`, `make_pick`, `pass_pick`, `re_draft_ban_check`
- Draft board / lottery / `eligibleRookiePool` queries and the make/pass/lottery/start/standings mutations

The live path **pre-creates the full ordered slate** so the UI can show who is on the clock, rather than inserting lazily as the importer does.

## Details worth a look

**Not a snake draft.** Rounds 2–5 all share one order (§7.2.1): non-playoff teams by reverse mid-season rank, then playoff teams by reverse playoff finish. Round 1 is the lottery for picks 1–6, then playoff teams by finish descending so the champion picks 12th.

**Traded picks.** Order is by a team's *natural* slot (`original_owner_team_id`) but the pick is *made by* `current_owner_team_id`. The lottery's ball count stays with the standings position even if that team traded the pick away — the balls belong to the slot, the resulting pick to the current owner.

**Lottery is auditable.** Seeded `StdRng` with the seed persisted at row creation (commit-reveal, per the spec's own recommendation) so owners can verify the draw was not re-rolled. `draw_is_reproducible_for_a_seed` and `ball_weighting_favours_the_worst_team` cover it.

**Roster room but no cap.** §7.3.2 requires an open roster slot and explicitly *not* cap space, since RD contracts are off-cap. The spec left open which limit applies during the draft window; this uses the preseason 32-man limit, noted in a comment at the check.

**Ordering is fully deterministic** — mid-season rank ties break by regular-season rank, then team id — so a replay cannot produce a different board.

## Known gaps

- `pass_pick` has **no unit test**, and I chose not to fake one. "A passed pick consumes its `order` slot" is enforced entirely in SQL (`get_on_the_clock_selection` filters `Status = Unused`, orders by `Order`), so a Rust helper re-implementing that ordering would assert nothing about real behavior. "Emits no team_update" is verified by reading the function. Filed as **fbkl-rust-u83**, alongside the same structural gap in `fbkl-rust-de1` — CI has no database and the suite is unit-only, so both want one shared DB harness.
- The scheduler does **not** auto-start the draft — the `PreseasonRookieDraftStart` processor arm is still a stub and only the commissioner's `startRookieDraft` mutation starts it. Wiring (plus the §7.2.2 lottery-after-SeasonEnd timing guard) is filed as **fbkl-rust-z2c**; the spec's frontend section is filed as **fbkl-rust-fdj**.

## Post-rebase fix

The rebase onto `main` picked up #86's `from_related_player(…, end_of_season_year)` signature change, which broke the eligible-pool resolver's call site — the tip didn't compile. Fixed in `c76d251`, which also corrects two comments that claimed the scheduler wiring already exists.

## Verification (at `c76d251`, post-rebase)

fmt clean · `clippy --workspace --all-targets -D warnings` 0 warnings · `nextest` 124/124 · doctests pass · SDL + codegen no drift · `tsc` clean.

Closes fbkl-rust-2jq.

https://claude.ai/code/session_013HAA7xG3vi5zUMCXABDus6
https://claude.ai/code/session_016pSWbsKkbGznWpbY3jdR5Y
