### PR TITLE
fix(auction): keep RFA/UFA minimums out of the tier slide

### DIFF
--- a/entity/src/queries/auction_queries.rs
+++ b/entity/src/queries/auction_queries.rs
@@ -9,7 +9,8 @@ use tracing::instrument;
 
 use crate::{
     auction::{self, AuctionKind, AuctionStatus},
-    auction_bid, contract,
+    auction_bid,
+    contract::{self, ContractKind},
     queries::pagination::{Paged, fetch_page},
     team_user,
 };
@@ -196,16 +197,18 @@ where
 }
 
 /// `Open` auctions of the given kind that have no bids yet and were last touched before
-/// `unchanged_before`.
+/// `unchanged_before`, skipping any whose contract kind is in `excluded_contract_kinds`.
 ///
 /// The timestamp bound keeps a freshly-opened auction from sliding a tier on its first day, and
-/// keeps an auction already slid today from sliding again on the next tick (rules §6.3.4).
+/// keeps an auction already slid today from sliding again on the next tick (rules §6.3.4). Which
+/// contract kinds sit out the ladder is a league rule, so the caller supplies them.
 #[instrument(skip(db))]
 pub async fn find_unbid_open_auctions<C>(
     league_id: i64,
     end_of_season_year: i16,
     kind: AuctionKind,
     unchanged_before: DateTimeWithTimeZone,
+    excluded_contract_kinds: &[ContractKind],
     db: &C,
 ) -> Result<Vec<auction::Model>>
 where
@@ -221,6 +224,7 @@ where
         .filter(auction_bid::Column::Id.is_null())
         .filter(contract::Column::LeagueId.eq(league_id))
         .filter(contract::Column::EndOfSeasonYear.eq(end_of_season_year))
+        .filter(contract::Column::Kind.is_not_in(excluded_contract_kinds.iter().copied()))
         .all(db)
         .await?;
     Ok(auction_models)

--- a/jobs/tests/veteran_auction_release.rs
+++ b/jobs/tests/veteran_auction_release.rs
@@ -85,6 +85,82 @@ async fn a_pooled_never_owned_veteran_opens_at_his_tier_minimum() {
     );
 }
 
+/// Rules §6.3.4-.5 vs §15.3.1: the daily tier slide is the ladder's clock for the scheduled tier
+/// pool only. An RFA opens at his 4th-year salary, so sliding him would price him under that floor.
+#[tokio::test]
+async fn the_tier_slide_leaves_an_unbid_rfa_at_his_carry_salary() {
+    const RFA_CARRY_SALARY: i16 = 7;
+
+    let Some(league) = TestLeague::create("veteran_auction_tier_slide", END_OF_SEASON_YEAR).await
+    else {
+        return;
+    };
+    league
+        .add_deadline(
+            DeadlineKind::PreseasonVeteranAuctionStart,
+            central("2025-09-01T12:00:00"),
+        )
+        .await;
+    league
+        .add_deadline(
+            DeadlineKind::PreseasonFinalRosterLock,
+            central("2025-10-20T18:00:00"),
+        )
+        .await;
+    league.add_min_bid_tiers(&TIER_MIN_BID_AMOUNTS).await;
+
+    let ranked_player_id = league.add_veteran_player("Ranked Vet").await;
+    league.add_ranked_players(&[ranked_player_id]).await;
+    let rfa_player_id = league.add_veteran_player("Restricted Vet").await;
+    league
+        .add_unowned_contract(
+            rfa_player_id,
+            ContractKind::RestrictedFreeAgent,
+            RFA_CARRY_SALARY,
+        )
+        .await;
+
+    assemble_veteran_auction_pool(league.league_id, END_OF_SEASON_YEAR, &league.db)
+        .await
+        .expect("assemble the veteran auction pool");
+
+    // Past RFA week, so both rows open at once.
+    let open_tick = central("2025-09-10T12:00:00");
+    let summary = run_veteran_auction_release_tick(&league.db, open_tick)
+        .await
+        .expect("run the release tick");
+    assert_eq!(summary.errors, 0);
+    assert_eq!(
+        open_auction_for(&league, ranked_player_id)
+            .await
+            .minimum_bid_amount,
+        TIER_MIN_BID_AMOUNTS[0]
+    );
+
+    // A day later both auctions are still unbid, so the slide tick is eligible to move them.
+    league.backdate_open_auctions(open_tick).await;
+    let slide_tick = central("2025-09-11T12:00:00");
+    let summary = run_veteran_auction_release_tick(&league.db, slide_tick)
+        .await
+        .expect("run the slide tick");
+    assert_eq!(summary.errors, 0);
+
+    assert_eq!(
+        open_auction_for(&league, ranked_player_id)
+            .await
+            .minimum_bid_amount,
+        TIER_MIN_BID_AMOUNTS[1],
+        "a plain pooled auction slides one tier"
+    );
+    assert_eq!(
+        open_auction_for(&league, rfa_player_id)
+            .await
+            .minimum_bid_amount,
+        RFA_CARRY_SALARY,
+        "the RFA minimum is his 4th-year salary, not the tier below it"
+    );
+}
+
 async fn open_auction_for(league: &TestLeague, player_id: i64) -> auction::Model {
     league
         .find_veteran_auction(player_id)

--- a/logic/src/auction/assemble_veteran_pool.rs
+++ b/logic/src/auction/assemble_veteran_pool.rs
@@ -47,6 +47,12 @@ static CARRY_SALARY_CONTRACT_KINDS: &[ContractKind] = &[
     ContractKind::UnrestrictedFreeAgentVeteran,
 ];
 
+/// Whether the auction for this contract is priced by carry salary rather than the §6.3.4 tier
+/// ladder — which also means the daily tier slide must leave its minimum alone.
+fn opens_at_carry_salary(kind: ContractKind) -> bool {
+    CARRY_SALARY_CONTRACT_KINDS.contains(&kind)
+}
+
 /// Assembles the season's veteran auction pool at/after the keeper deadline.
 ///
 /// Creates the pooled contract for every eligible unkept veteran and writes the `auction_schedule`
@@ -263,7 +269,7 @@ where
     )
     .await?;
 
-    let minimum_bid_amount = if CARRY_SALARY_CONTRACT_KINDS.contains(&pooled_contract.kind) {
+    let minimum_bid_amount = if opens_at_carry_salary(pooled_contract.kind) {
         pooled_contract.salary
     } else {
         auction_schedule_queries::find_min_bid_tier_by_index(
@@ -284,12 +290,11 @@ where
         .min_bid_amount
     };
 
-    let maybe_original_owner_team_id =
-        if CARRY_SALARY_CONTRACT_KINDS.contains(&pooled_contract.kind) {
-            find_original_owner_team_id(&pooled_contract, db).await?
-        } else {
-            None
-        };
+    let maybe_original_owner_team_id = if opens_at_carry_salary(pooled_contract.kind) {
+        find_original_owner_team_id(&pooled_contract, db).await?
+    } else {
+        None
+    };
 
     // With no bids the §6.3.4 tier ladder is the clock; the daily slide pushes this close time out.
     let mode_deadlines = find_auction_mode_deadlines(
@@ -331,6 +336,10 @@ where
 /// into a tier does not push that tier's existing players down (§6.3.5). Auctions opened within the
 /// last day are skipped so a fresh open does not slide the same day; the day the slide finds no lower
 /// tier, the auction's lapsed close time expires it and the player becomes a $1 FA (§6.1.2).
+///
+/// Carry-salary auctions sit out the ladder entirely: an RFA opens at the player's 4th-year salary
+/// (§15.3.1) and a UFA at his carry salary (§16), so sliding one would price him under the rules.
+/// Their clock is the RFA week plus the hard deadline, not the tier ladder.
 #[instrument(skip(db))]
 pub async fn slide_unbid_auctions_down_a_tier<C>(
     league_id: i64,
@@ -349,6 +358,7 @@ where
         end_of_season_year,
         AuctionKind::PreseasonVeteranAuction,
         opened_before,
+        CARRY_SALARY_CONTRACT_KINDS,
         db,
     )
     .await?;
@@ -464,10 +474,11 @@ fn release_date(first_date: Date, position: usize, players_per_day: usize) -> Re
 #[cfg(test)]
 mod tests {
     use chrono::{Days, NaiveDate};
-    use fbkl_entity::sea_orm::prelude::DateTimeWithTimeZone;
+    use fbkl_entity::{contract::ContractKind, sea_orm::prelude::DateTimeWithTimeZone};
 
     use super::{
-        auction_close_at, auction_quiet_window, next_lower_min_bid_amount, release_date, tier_slot,
+        auction_close_at, auction_quiet_window, next_lower_min_bid_amount, opens_at_carry_salary,
+        release_date, tier_slot,
     };
 
     /// A veteran auction never has an all-bid deadline, and the ladder step ignores the crunch window.
@@ -512,6 +523,22 @@ mod tests {
 
         assert_eq!(minimums_walked, vec![15, 10, 5]);
         assert_eq!(minimum_bid_amount, 5);
+    }
+
+    /// Rules §15.3.1 / §16: the ladder prices the scheduled tier pool, never a carry-salary auction.
+    /// `slide_unbid_auctions_down_a_tier` passes these kinds to the query as the exclusion list.
+    #[test]
+    fn carry_salary_auctions_sit_out_the_tier_ladder() {
+        assert!(opens_at_carry_salary(ContractKind::RestrictedFreeAgent));
+        assert!(opens_at_carry_salary(
+            ContractKind::UnrestrictedFreeAgentOriginalTeam
+        ));
+        assert!(opens_at_carry_salary(
+            ContractKind::UnrestrictedFreeAgentVeteran
+        ));
+        // A pooled non-carry contract opens at its tier value, so the ladder still moves it.
+        assert!(!opens_at_carry_salary(ContractKind::FreeAgent));
+        assert!(!opens_at_carry_salary(ContractKind::Veteran));
     }
 
     #[test]

--- a/test-support/src/lib.rs
+++ b/test-support/src/lib.rs
@@ -7,7 +7,7 @@
 //! database.
 
 use fbkl_entity::{
-    auction::{self, AuctionKind},
+    auction::{self, AuctionKind, AuctionStatus},
     auction_queries,
     auction_schedule_queries::{self, NewAuctionScheduleRow},
     contract::{self, ContractKind, ContractStatus},
@@ -17,8 +17,9 @@ use fbkl_entity::{
     player::{self, NbaRosterSource, PlayerStatus},
     position, real_team,
     sea_orm::{
-        ActiveModelTrait, ActiveValue, ConnectionTrait, Database, DatabaseConnection, EntityTrait,
-        prelude::{Date, DateTimeWithTimeZone},
+        ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, Database, DatabaseConnection,
+        EntityTrait, QueryFilter,
+        prelude::{Date, DateTimeWithTimeZone, Expr},
     },
     team,
     team_user::{self, LeagueRole},
@@ -157,6 +158,23 @@ impl TestLeague {
         .insert(&self.db)
         .await
         .expect("insert team user")
+    }
+
+    /// Rewinds every open auction's start and update timestamps, i.e. simulates a day passing with
+    /// nobody touching them.
+    ///
+    /// `auction.updated_at` is stamped by the database clock, so a test driving ticks from
+    /// simulated timestamps can never otherwise satisfy the tier slide's untouched-for-a-day bound.
+    /// The write sets `updated_at` itself, which is what keeps the `set_updated_at` trigger from
+    /// stamping the row back to the wall clock.
+    pub async fn backdate_open_auctions(&self, timestamp: DateTimeWithTimeZone) {
+        auction::Entity::update_many()
+            .col_expr(auction::Column::StartTimestamp, Expr::value(timestamp))
+            .col_expr(auction::Column::UpdatedAt, Expr::value(timestamp))
+            .filter(auction::Column::Status.eq(AuctionStatus::Open))
+            .exec(&self.db)
+            .await
+            .expect("backdate open auctions");
     }
 
     /// The veteran auction opened for `player_id`, whatever state it has since reached.


### PR DESCRIPTION
Closes `fbkl-rust-0hk`.

## Problem

`slide_unbid_auctions_down_a_tier` filtered on `AuctionKind` alone, so unbid RFA and UFA auctions slid down the ladder along with the scheduled tier pool. Those auctions open at their carry salary, and the slide rewrote that minimum to the highest configured tier value below it - pricing the player under his 4th-year salary (rules 15.3.1) or carry salary (16). The 6.3.4 tier ladder governs the scheduled tier pool, not carry-salary contracts, whose clock is RFA week plus the hard deadline.

## Fix

- `find_unbid_open_auctions` takes an `excluded_contract_kinds: &[ContractKind]` slice and filters `contract.kind NOT IN` it. The join to `contract` was already there for the league/season filters. Passing the list in keeps league-rule knowledge out of `entity/`.
- `slide_unbid_auctions_down_a_tier` passes `CARRY_SALARY_CONTRACT_KINDS`.
- Extracted `opens_at_carry_salary()` so the two `open_scheduled_auction` call sites and the slide share one predicate instead of three `.contains()` checks.

## Testing

New DB-backed test `the_tier_slide_leaves_an_unbid_rfa_at_his_carry_salary`: an unbid RFA at 7 holds his minimum across two release ticks while the ranked plain-FA auction slides 20 -> 15. Confirmed it fails without the fix (RFA slid to 5).

This needed a new `TestLeague::backdate_open_auctions` helper. `auction.updated_at` is stamped by the DB clock via the `set_updated_at` trigger, so a test driving ticks from simulated timestamps could never satisfy the slide's untouched-for-a-day bound - which is why the slide had no coverage before. The helper sets `updated_at` explicitly in the UPDATE, which is what stops the trigger overwriting it.

Gates: `cargo nextest run --workspace` 126 passed / 0 failed, `cargo clippy --workspace --all-targets -- -D warnings` clean, `cargo fmt` applied.

https://claude.ai/code/session_019WSU2E5cSzorBptjfktsPh