### PR TITLE
refactor(test-support): move scratch_db into its own module

### DIFF
--- a/test-support/src/lib.rs
+++ b/test-support/src/lib.rs
@@ -17,7 +17,33 @@
 //! Rewind those columns before the tick that should act on them; `backdate_open_auctions` does it
 //! for the veteran auction tier slide. The trigger only stamps the wall clock when the UPDATE did
 //! not set `updated_at` itself, so writing it explicitly is what makes the rewind stick.
+//!
+//! # Growing the harness
+//!
+//! New helpers default to methods on [`TestLeague`]. When the impl block gets long, split it across
+//! modules (`impl TestLeague` can live in more than one file) rather than inventing a type to hold
+//! the overflow.
+//!
+//! A separate fixture struct earns its place only when it carries state `TestLeague` cannot — its
+//! own ids or invariants — not merely because it covers a different domain. A struct that wraps
+//! `TestLeague` and forwards every call is one implementation behind one interface, and costs a
+//! layer of indirection for nothing. Trades are the case that will actually qualify: `team_id` here
+//! is singular, so a two-team fixture needs a shape this struct cannot express.
+//!
+//! When that happens, borrow rather than rebuild — reach the new fixture through an accessor so it
+//! shares the already-migrated database:
+//!
+//! ```ignore
+//! pub struct TestTrade<'a> { league: &'a TestLeague, team_a: i64, team_b: i64 }
+//!
+//! impl TestLeague {
+//!     pub fn trade(&self, team_a: i64, team_b: i64) -> TestTrade<'_> { .. }
+//! }
+//! ```
 
+mod scratch_db;
+
+use crate::scratch_db::scratch_db;
 use fbkl_entity::{
     auction::{self, AuctionKind, AuctionStatus},
     auction_queries,
@@ -29,15 +55,13 @@ use fbkl_entity::{
     player::{self, NbaRosterSource, PlayerStatus},
     position, real_team,
     sea_orm::{
-        ActiveModelTrait, ActiveValue, ColumnTrait, ConnectionTrait, Database, DatabaseConnection,
-        EntityTrait, QueryFilter,
+        ActiveModelTrait, ActiveValue, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter,
         prelude::{Date, DateTimeWithTimeZone, Expr},
     },
     team,
     team_user::{self, LeagueRole},
     user,
 };
-use fbkl_migration::{Migrator, MigratorTrait};
 
 /// A migrated scratch database holding one league, one team, and one real NBA team to hang
 /// players off.
@@ -277,41 +301,4 @@ pub fn central(timestamp: &str) -> DateTimeWithTimeZone {
     format!("{timestamp}-06:00")
         .parse()
         .expect("parse timestamp")
-}
-
-/// Drops and recreates `fbkl_test_<test_name>` next to `DATABASE_URL`, then migrates it.
-async fn scratch_db(test_name: &str) -> Option<DatabaseConnection> {
-    dotenvy::dotenv().ok();
-    let Ok(base_url) = std::env::var("DATABASE_URL") else {
-        eprintln!("skipping {test_name}: DATABASE_URL not set");
-        return None;
-    };
-
-    let (host_url, _) = base_url
-        .trim_end_matches('/')
-        .rsplit_once('/')
-        .expect("DATABASE_URL must end in a database name");
-    let scratch_name = format!("fbkl_test_{test_name}");
-
-    let admin_db = Database::connect(format!("{host_url}/postgres"))
-        .await
-        .expect("connect to the postgres maintenance database");
-    admin_db
-        .execute_unprepared(&format!(
-            "DROP DATABASE IF EXISTS {scratch_name} WITH (FORCE)"
-        ))
-        .await
-        .expect("drop scratch database");
-    admin_db
-        .execute_unprepared(&format!("CREATE DATABASE {scratch_name}"))
-        .await
-        .expect("create scratch database");
-
-    let db = Database::connect(format!("{host_url}/{scratch_name}"))
-        .await
-        .expect("connect to scratch database");
-    Migrator::up(&db, None)
-        .await
-        .expect("migrate scratch database");
-    Some(db)
 }

--- a/test-support/src/scratch_db.rs
+++ b/test-support/src/scratch_db.rs
@@ -1,0 +1,42 @@
+//! Per-test scratch database creation, i.e. the harness plumbing that has nothing to do with
+//! fantasy basketball.
+
+use fbkl_entity::sea_orm::{ConnectionTrait, Database, DatabaseConnection};
+use fbkl_migration::{Migrator, MigratorTrait};
+
+/// Drops and recreates `fbkl_test_<test_name>` next to `DATABASE_URL`, then migrates it.
+pub async fn scratch_db(test_name: &str) -> Option<DatabaseConnection> {
+    dotenvy::dotenv().ok();
+    let Ok(base_url) = std::env::var("DATABASE_URL") else {
+        eprintln!("skipping {test_name}: DATABASE_URL not set");
+        return None;
+    };
+
+    let (host_url, _) = base_url
+        .trim_end_matches('/')
+        .rsplit_once('/')
+        .expect("DATABASE_URL must end in a database name");
+    let scratch_name = format!("fbkl_test_{test_name}");
+
+    let admin_db = Database::connect(format!("{host_url}/postgres"))
+        .await
+        .expect("connect to the postgres maintenance database");
+    admin_db
+        .execute_unprepared(&format!(
+            "DROP DATABASE IF EXISTS {scratch_name} WITH (FORCE)"
+        ))
+        .await
+        .expect("drop scratch database");
+    admin_db
+        .execute_unprepared(&format!("CREATE DATABASE {scratch_name}"))
+        .await
+        .expect("create scratch database");
+
+    let db = Database::connect(format!("{host_url}/{scratch_name}"))
+        .await
+        .expect("connect to scratch database");
+    Migrator::up(&db, None)
+        .await
+        .expect("migrate scratch database");
+    Some(db)
+}


### PR DESCRIPTION
## What

Splits `test-support/src/lib.rs` along its one real seam: `scratch_db` moves to `test-support/src/scratch_db.rs`.

`scratch_db` is generic Postgres plumbing with no fantasy-basketball domain in it, so it changes for different reasons than the league-fixture builders it sat next to (pooling, template databases, parallel isolation vs. "this test needs a new row type"). Splitting it lets either evolve without touching the other.

Also appends a `# Growing the harness` section to the `lib.rs` module doc, recording when to add a method vs. a type:

- Needs only existing fields → method on `TestLeague`; split the impl across modules when it gets long.
- Needs its own fields or invariants → new borrowing struct, reached via an accessor.
- Wraps `TestLeague` and forwards → don't.

Trades are the case that will actually qualify: `TestLeague.team_id` is singular, so a two-team fixture needs a shape the struct can't express.

## Notes

- The doc's `TestTrade` example is fenced `ignore` because the type doesn't exist yet; a plain fence would fail `cargo test --doc`.
- `scratch_db` is `pub`, not `pub(crate)` — clippy nursery's `redundant_pub_crate` fires on the latter inside a private module. Visibility is identical either way; `mod scratch_db` isn't public.
- No consumer changes: `fbkl_test_support::{TestLeague, central}` paths are untouched across all 5 test files.

## Testing

- `cargo build --workspace --all-targets` — clean
- `cargo nextest run --workspace` — 126/126 pass, including the 10 DB-backed `fbkl-jobs`/`fbkl-server` tests that exercise the moved path
- `cargo test --doc -p fbkl-test-support` — new block correctly skipped
- `cargo clippy` / `cargo fmt --check` — clean

https://claude.ai/code/session_011P8pPUDmrFBEtYpKYLsEgo